### PR TITLE
Add deployment script for hocai.site

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Website giới thiệu cây thuốc nam và bài thuốc gia truyền của dân
 - Dữ liệu chủ đề và tin tức lưu trong MariaDB (tự tạo bảng `topics` và `news_items` khi khởi động lần đầu).
 
 ## Cài đặt
+**Cài đặt nhanh:**
+```bash
+chmod +x install.sh
+./install.sh
+```
+Script sẽ tạo `.venv`, cài gói Python và ghi file `.env` với thông tin miền `hocai.site`, tài khoản quản trị (`admin` / `phat2009`) và kết nối MariaDB mặc định.
+
+**Cài đặt thủ công:**
 1. Tạo môi trường ảo và cài đặt phụ thuộc:
    ```bash
    python -m venv .venv
@@ -41,7 +49,8 @@ Kịch bản `deploy.sh` hỗ trợ upload mã nguồn và khởi chạy Gunicor
    export REMOTE_DIR=/var/www/hocai   # thư mục lưu mã nguồn
    export DATABASE_URL="mysql+pymysql://h51ecb951c_hocai:phat2009@localhost/h51ecb951c_hocai?charset=utf8mb4"
    export SECRET_KEY="<chuoi-bi-mat>"
-   export ADMIN_PASSWORD="<mat-khau-quan-tri>"
+    export ADMIN_USERNAME=admin
+   export ADMIN_PASSWORD="phat2009"
    export SERVER_NAME=hocai.site
    ```
 3. Chạy script triển khai:
@@ -79,7 +88,8 @@ Kịch bản `deploy.sh` hỗ trợ upload mã nguồn và khởi chạy Gunicor
 - Khi triển khai sau LiteSpeed, hãy chạy ứng dụng bằng WSGI (ví dụ `gunicorn --workers 2 --threads 2 app:app`) và để LiteSpeed/LSAPI reverse proxy tới port nội bộ; tránh chạy debug để tiết kiệm bộ nhớ.
 
 ## Tài khoản quản trị
-- Mật khẩu mặc định: `tientocham`
+- Tài khoản mặc định: `admin`
+- Mật khẩu mặc định: `phat2009`
 - URL đăng nhập: `/admin/login`
 
 ## Tùy chỉnh

--- a/README.md
+++ b/README.md
@@ -44,21 +44,21 @@ source /home/h51ecb951c/virtualenv/hocai.site/3.11/bin/activate && cd /home/h51e
    flask --app app run --host 0.0.0.0 --port 5000
    ```
 
-## Triển khai lên máy chủ (hocai.site)
-Kịch bản `deploy.sh` hỗ trợ upload mã nguồn và khởi chạy Gunicorn sau LiteSpeed/Apache/nginx. Yêu cầu có SSH vào máy chủ.
+## Triển khai lên máy chủ LiteSpeed (hocai.site)
+Kịch bản `deploy.sh` đồng bộ mã nguồn, cài phụ thuộc vào đúng virtualenv và kích hoạt reload theo chuẩn LiteSpeed/Setup Python App (Passenger). Yêu cầu có SSH vào máy chủ.
 
 1. Tạo bản ghi DNS A cho `hocai.site` trỏ tới IP máy chủ.
 2. Thiết lập biến môi trường (tùy chỉnh khi cần, máy chủ SSH `cda004.secureweb.vn` mở port 2222):
    ```bash
    export SSH_HOST=cda004.secureweb.vn
    export SSH_PORT=2222
-   export SSH_USER=root                                # hoặc tài khoản có quyền sudo
-   export REMOTE_DIR=/home/h51ecb951c/domains/hocai.site                 # thư mục lưu mã nguồn
+   export SSH_USER=h51ecb951c
+   export REMOTE_DIR=/home/h51ecb951c/domains/hocai.site
    export VENV_DIR=/home/h51ecb951c/virtualenv/hocai.site/3.11
-   export PYTHON_BIN=python3.11                        # khớp cấu hình "Setup Python App 3.11.11"
+   export PYTHON_BIN=python3                            # phù hợp Setup Python App 3.11.11
    export DATABASE_URL="mysql+pymysql://h51ecb951c_hocai:phat2009@localhost/h51ecb951c_hocai?charset=utf8mb4"
    export SECRET_KEY="<chuoi-bi-mat>"
-    export ADMIN_USERNAME=admin
+   export ADMIN_USERNAME=admin
    export ADMIN_PASSWORD="phat2009"
    export SERVER_NAME=hocai.site
    ```
@@ -66,27 +66,14 @@ Kịch bản `deploy.sh` hỗ trợ upload mã nguồn và khởi chạy Gunicor
    ```bash
    ./deploy.sh
    ```
-   Script sẽ đồng bộ mã nguồn bằng `rsync`, cài gói trong môi trường ảo tại `/home/h51ecb951c/virtualenv/hocai.site/3.11`, khởi tạo bảng CSDL và tạo dịch vụ systemd chạy Gunicorn tại `127.0.0.1:8000`.
-4. Cấu hình web server (ví dụ LiteSpeed/Apache) reverse proxy `hocai.site` tới `127.0.0.1:8000`, bật HTTPS và HTTP/2 để tận dụng SEO. Với Apache, có thể dùng cấu hình mẫu:
-   ```apache
-   <VirtualHost *:80>
-     ServerName hocai.site
-     Redirect permanent / https://hocai.site/
-   </VirtualHost>
-
-   <VirtualHost *:443>
-     ServerName hocai.site
-     ProxyPreserveHost On
-     ProxyPass / http://127.0.0.1:8000/
-     ProxyPassReverse / http://127.0.0.1:8000/
-     SSLEngine on
-     SSLCertificateFile /etc/letsencrypt/live/hocai.site/fullchain.pem
-     SSLCertificateKeyFile /etc/letsencrypt/live/hocai.site/privkey.pem
-   </VirtualHost>
-   ```
-5. Kiểm tra dịch vụ:
+   Script sẽ `rsync` mã nguồn, cài gói trong môi trường ảo tại `/home/h51ecb951c/virtualenv/hocai.site/3.11`, khởi tạo bảng CSDL và `touch /home/h51ecb951c/domains/hocai.site/tmp/restart.txt` để LiteSpeed nạp lại ứng dụng.
+4. Trên giao diện **Setup Python App** của LiteSpeed/cPanel, hãy đảm bảo:
+   - Application root: `/home/h51ecb951c/domains/hocai.site`
+   - Application URL: `hocai.site/`
+   - Startup file: `passenger_wsgi.py` (hoặc `app.py` nếu host hỗ trợ trực tiếp)
+   - Python version: `3.11`
+5. Kiểm tra nhanh sau triển khai:
    ```bash
-   sudo systemctl status hocai-site.service
    curl -I https://hocai.site
    ```
    Khi cần cập nhật mã, chỉ cần chạy lại `./deploy.sh`.

--- a/README.md
+++ b/README.md
@@ -10,17 +10,18 @@ Website giới thiệu cây thuốc nam và bài thuốc gia truyền của dân
 - Dữ liệu chủ đề và tin tức lưu trong MariaDB (tự tạo bảng `topics` và `news_items` khi khởi động lần đầu).
 
 ## Cài đặt
-**Cài đặt nhanh:**
+**Cài đặt nhanh (đã khớp môi trường Setup Python App 3.11.11):**
 ```bash
 chmod +x install.sh
 ./install.sh
 ```
-Script sẽ tạo `.venv`, cài gói Python và ghi file `.env` với thông tin miền `hocai.site`, tài khoản quản trị (`admin` / `phat2009`) và kết nối MariaDB mặc định.
+Script sẽ tạo `.venv` với Python 3.11, cài gói và ghi file `.env` với thông tin miền `hocai.site`, tài khoản quản trị (`admin` / `phat2009`) và kết nối MariaDB mặc định.
+Nếu máy chủ có nhiều phiên bản Python, đặt biến `PYTHON_BIN=python3.11` trước khi chạy để khớp "Setup Python App 3.11.11".
 
 **Cài đặt thủ công:**
 1. Tạo môi trường ảo và cài đặt phụ thuộc:
    ```bash
-   python -m venv .venv
+   python3.11 -m venv .venv
    source .venv/bin/activate
    pip install -r requirements.txt
    ```
@@ -47,6 +48,7 @@ Kịch bản `deploy.sh` hỗ trợ upload mã nguồn và khởi chạy Gunicor
    export SSH_HOST=hocai.site
    export SSH_USER=root               # hoặc tài khoản có quyền sudo
    export REMOTE_DIR=/var/www/hocai   # thư mục lưu mã nguồn
+   export PYTHON_BIN=python3.11       # khớp cấu hình "Setup Python App 3.11.11"
    export DATABASE_URL="mysql+pymysql://h51ecb951c_hocai:phat2009@localhost/h51ecb951c_hocai?charset=utf8mb4"
    export SECRET_KEY="<chuoi-bi-mat>"
     export ADMIN_USERNAME=admin

--- a/README.md
+++ b/README.md
@@ -15,14 +15,17 @@ Website giới thiệu cây thuốc nam và bài thuốc gia truyền của dân
 chmod +x install.sh
 ./install.sh
 ```
-Script sẽ tạo `.venv` với Python 3.11, cài gói và ghi file `.env` với thông tin miền `hocai.site`, tài khoản quản trị (`admin` / `phat2009`) và kết nối MariaDB mặc định.
-Nếu máy chủ có nhiều phiên bản Python, đặt biến `PYTHON_BIN=python3.11` trước khi chạy để khớp "Setup Python App 3.11.11".
+Script sẽ tạo môi trường ảo tại `/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11` (hoặc dùng lại nếu đã có), cài gói và ghi file `.env` với thông tin miền `hocai.site`, tài khoản quản trị (`admin` / `phat2009`) và kết nối MariaDB mặc định.
+Nếu máy chủ có nhiều phiên bản Python, đặt biến `PYTHON_BIN=python3.11` trước khi chạy để khớp "Setup Python App 3.11.11". Khi đăng nhập SSH, kích hoạt sẵn môi trường ảo và chuyển thư mục bằng:
+```bash
+source /home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11/bin/activate && cd /home/h51ecb951c/hocai.site/var/www/hocai
+```
 
 **Cài đặt thủ công:**
-1. Tạo môi trường ảo và cài đặt phụ thuộc:
+1. Tạo môi trường ảo và cài đặt phụ thuộc (đường dẫn khớp máy chủ đã cấu hình):
    ```bash
-   python3.11 -m venv .venv
-   source .venv/bin/activate
+   python3.11 -m venv /home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11
+   source /home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11/bin/activate
    pip install -r requirements.txt
    ```
 2. Cấu hình kết nối MariaDB (mặc định dùng thông tin máy chủ nội bộ):
@@ -46,9 +49,10 @@ Kịch bản `deploy.sh` hỗ trợ upload mã nguồn và khởi chạy Gunicor
 2. Thiết lập biến môi trường (tùy chỉnh khi cần):
    ```bash
    export SSH_HOST=hocai.site
-   export SSH_USER=root               # hoặc tài khoản có quyền sudo
-   export REMOTE_DIR=/var/www/hocai   # thư mục lưu mã nguồn
-   export PYTHON_BIN=python3.11       # khớp cấu hình "Setup Python App 3.11.11"
+   export SSH_USER=root                                # hoặc tài khoản có quyền sudo
+   export REMOTE_DIR=/home/h51ecb951c/hocai.site/var/www/hocai   # thư mục lưu mã nguồn
+   export VENV_DIR=/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11
+   export PYTHON_BIN=python3.11                        # khớp cấu hình "Setup Python App 3.11.11"
    export DATABASE_URL="mysql+pymysql://h51ecb951c_hocai:phat2009@localhost/h51ecb951c_hocai?charset=utf8mb4"
    export SECRET_KEY="<chuoi-bi-mat>"
     export ADMIN_USERNAME=admin
@@ -59,7 +63,7 @@ Kịch bản `deploy.sh` hỗ trợ upload mã nguồn và khởi chạy Gunicor
    ```bash
    ./deploy.sh
    ```
-   Script sẽ đồng bộ mã nguồn bằng `rsync`, cài gói trong `.venv`, khởi tạo bảng CSDL và tạo dịch vụ systemd chạy Gunicorn tại `127.0.0.1:8000`.
+   Script sẽ đồng bộ mã nguồn bằng `rsync`, cài gói trong môi trường ảo tại `/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11`, khởi tạo bảng CSDL và tạo dịch vụ systemd chạy Gunicorn tại `127.0.0.1:8000`.
 4. Cấu hình web server (ví dụ LiteSpeed/Apache) reverse proxy `hocai.site` tới `127.0.0.1:8000`, bật HTTPS và HTTP/2 để tận dụng SEO. Với Apache, có thể dùng cấu hình mẫu:
    ```apache
    <VirtualHost *:80>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ bash install.sh   # hoặc ./install.sh nếu có quyền thực thi
 Script sẽ tạo môi trường ảo tại `/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11` (hoặc dùng lại nếu đã có), cài gói và ghi file `.env` với thông tin miền `hocai.site`, tài khoản quản trị (`admin` / `phat2009`) và kết nối MariaDB mặc định.
 Nếu máy chủ có nhiều phiên bản Python, đặt biến `PYTHON_BIN=python3.11` trước khi chạy để khớp "Setup Python App 3.11.11" (script tự động fallback sang python3.11 nếu `python3` không tồn tại). Khi đăng nhập SSH, kích hoạt sẵn môi trường ảo và chuyển thư mục bằng:
 ```bash
-source /home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11/bin/activate && cd /home/h51ecb951c/hocai.site/var/www/hocai
+source /home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11/bin/activate && cd /home/h51ecb951c/domains/hocai.site/var/www/hocai
 ```
 
 **Cài đặt thủ công:**
@@ -53,7 +53,7 @@ Kịch bản `deploy.sh` hỗ trợ upload mã nguồn và khởi chạy Gunicor
    export SSH_HOST=cda004.secureweb.vn
    export SSH_PORT=2222
    export SSH_USER=root                                # hoặc tài khoản có quyền sudo
-   export REMOTE_DIR=/home/h51ecb951c/hocai.site/var/www/hocai   # thư mục lưu mã nguồn
+   export REMOTE_DIR=/home/h51ecb951c/domains/hocai.site/var/www/hocai   # thư mục lưu mã nguồn
    export VENV_DIR=/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11
    export PYTHON_BIN=python3.11                        # khớp cấu hình "Setup Python App 3.11.11"
    export DATABASE_URL="mysql+pymysql://h51ecb951c_hocai:phat2009@localhost/h51ecb951c_hocai?charset=utf8mb4"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,90 @@
-# hocai
-học ai chơi sàn binane
+# Nhà thuốc Nam Thiên Tâm
+
+Website giới thiệu cây thuốc nam và bài thuốc gia truyền của dân tộc Chăm, tập trung vào các chủ đề: sỏi thận, viêm cầu thận, suy thận, viêm tiết niệu, làm đẹp da, viêm khớp, thoái hóa khớp và gout. Dự án xây dựng bằng Python/Flask với giao diện màu xanh lá cây chủ đạo, tối ưu SEO và có trang quản trị dễ dùng.
+
+## Tính năng chính
+- Trang chủ hiển thị giới thiệu, danh sách chủ đề và 4 tin tức mới nhất.
+- Trang chi tiết từng chủ đề với tóm tắt và các bước/bài thuốc gợi ý.
+- Trang tin tức tự động tổng hợp 10 bài viết chất lượng, cho phép thêm/xóa qua quản trị.
+- Trang quản trị (đăng nhập bằng mật khẩu) để thêm, cập nhật, xóa chủ đề và tin tức.
+- Dữ liệu chủ đề và tin tức lưu trong MariaDB (tự tạo bảng `topics` và `news_items` khi khởi động lần đầu).
+
+## Cài đặt
+1. Tạo môi trường ảo và cài đặt phụ thuộc:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. Cấu hình kết nối MariaDB (mặc định dùng thông tin máy chủ nội bộ):
+   - Host: `localhost` (Unix socket)
+   - User: `h51ecb951c_hocai`
+   - Password: `phat2009`
+   - Database: `h51ecb951c_hocai`
+   - Charset: `utf8mb4`
+
+   Chỉnh sửa chuỗi kết nối trong `app.py` nếu máy chủ của bạn khác thông tin trên.
+
+3. Chạy ứng dụng:
+   ```bash
+   flask --app app run --host 0.0.0.0 --port 5000
+   ```
+
+## Triển khai lên máy chủ (hocai.site)
+Kịch bản `deploy.sh` hỗ trợ upload mã nguồn và khởi chạy Gunicorn sau LiteSpeed/Apache/nginx. Yêu cầu có SSH vào máy chủ.
+
+1. Tạo bản ghi DNS A cho `hocai.site` trỏ tới IP máy chủ.
+2. Thiết lập biến môi trường (tùy chỉnh khi cần):
+   ```bash
+   export SSH_HOST=hocai.site
+   export SSH_USER=root               # hoặc tài khoản có quyền sudo
+   export REMOTE_DIR=/var/www/hocai   # thư mục lưu mã nguồn
+   export DATABASE_URL="mysql+pymysql://h51ecb951c_hocai:phat2009@localhost/h51ecb951c_hocai?charset=utf8mb4"
+   export SECRET_KEY="<chuoi-bi-mat>"
+   export ADMIN_PASSWORD="<mat-khau-quan-tri>"
+   export SERVER_NAME=hocai.site
+   ```
+3. Chạy script triển khai:
+   ```bash
+   ./deploy.sh
+   ```
+   Script sẽ đồng bộ mã nguồn bằng `rsync`, cài gói trong `.venv`, khởi tạo bảng CSDL và tạo dịch vụ systemd chạy Gunicorn tại `127.0.0.1:8000`.
+4. Cấu hình web server (ví dụ LiteSpeed/Apache) reverse proxy `hocai.site` tới `127.0.0.1:8000`, bật HTTPS và HTTP/2 để tận dụng SEO. Với Apache, có thể dùng cấu hình mẫu:
+   ```apache
+   <VirtualHost *:80>
+     ServerName hocai.site
+     Redirect permanent / https://hocai.site/
+   </VirtualHost>
+
+   <VirtualHost *:443>
+     ServerName hocai.site
+     ProxyPreserveHost On
+     ProxyPass / http://127.0.0.1:8000/
+     ProxyPassReverse / http://127.0.0.1:8000/
+     SSLEngine on
+     SSLCertificateFile /etc/letsencrypt/live/hocai.site/fullchain.pem
+     SSLCertificateKeyFile /etc/letsencrypt/live/hocai.site/privkey.pem
+   </VirtualHost>
+   ```
+5. Kiểm tra dịch vụ:
+   ```bash
+   sudo systemctl status hocai-site.service
+   curl -I https://hocai.site
+   ```
+   Khi cần cập nhật mã, chỉ cần chạy lại `./deploy.sh`.
+
+## Tối ưu hiệu năng trên máy chủ LiteSpeed/PHP 7.4
+- `SQLALCHEMY_ENGINE_OPTIONS` đã được tinh chỉnh sẵn với pool nhỏ (5 kết nối, tối đa vượt mức 2) kèm `pool_pre_ping`/`pool_recycle` giúp tái sử dụng kết nối ổn định trên MariaDB 10.5.
+- Ẩn dư thừa SSL và bật cache nội bộ cho danh sách chủ đề/tin giúp giảm số truy vấn cho mỗi request, phù hợp môi trường tài nguyên hạn chế.
+- Khi triển khai sau LiteSpeed, hãy chạy ứng dụng bằng WSGI (ví dụ `gunicorn --workers 2 --threads 2 app:app`) và để LiteSpeed/LSAPI reverse proxy tới port nội bộ; tránh chạy debug để tiết kiệm bộ nhớ.
+
+## Tài khoản quản trị
+- Mật khẩu mặc định: `tientocham`
+- URL đăng nhập: `/admin/login`
+
+## Tùy chỉnh
+- Tùy chỉnh dữ liệu trực tiếp bằng giao diện quản trị hoặc qua MariaDB.
+- Thay đổi màu sắc hoặc giao diện trong `static/css/style.css`.
+
+## Ghi chú
+Máy chủ cần có kết nối mạng để cài đặt `Flask` từ `pip`. Nếu không thể tải gói, hãy cài đặt thủ công từ nguồn sẵn có hoặc sử dụng môi trường đã có Flask.

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ source /home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11/bin/activate &&
 Kịch bản `deploy.sh` hỗ trợ upload mã nguồn và khởi chạy Gunicorn sau LiteSpeed/Apache/nginx. Yêu cầu có SSH vào máy chủ.
 
 1. Tạo bản ghi DNS A cho `hocai.site` trỏ tới IP máy chủ.
-2. Thiết lập biến môi trường (tùy chỉnh khi cần):
+2. Thiết lập biến môi trường (tùy chỉnh khi cần, máy chủ SSH `cda004.secureweb.vn` mở port 2222):
    ```bash
-   export SSH_HOST=hocai.site
+   export SSH_HOST=cda004.secureweb.vn
+   export SSH_PORT=2222
    export SSH_USER=root                                # hoặc tài khoản có quyền sudo
    export REMOTE_DIR=/home/h51ecb951c/hocai.site/var/www/hocai   # thư mục lưu mã nguồn
    export VENV_DIR=/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11

--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ bash install.sh   # hoặc ./install.sh nếu có quyền thực thi
 ```
 > Lưu ý: đừng chạy nhầm `pip install install.sh` hoặc đưa file này vào danh sách yêu cầu của pip; pip sẽ coi dòng `set -euo pipefail` là gói và báo lỗi như "Invalid requirement: set -e". Hãy thực thi script bằng Bash.
 
-Script sẽ tạo môi trường ảo tại `/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11` (hoặc dùng lại nếu đã có), cài gói và ghi file `.env` với thông tin miền `hocai.site`, tài khoản quản trị (`admin` / `phat2009`) và kết nối MariaDB mặc định.
+Script sẽ tạo môi trường ảo tại `/home/h51ecb951c/virtualenv/hocai.site/3.11` (hoặc dùng lại nếu đã có), cài gói và ghi file `.env` với thông tin miền `hocai.site`, tài khoản quản trị (`admin` / `phat2009`) và kết nối MariaDB mặc định.
 Nếu máy chủ có nhiều phiên bản Python, đặt biến `PYTHON_BIN=python3.11` trước khi chạy để khớp "Setup Python App 3.11.11" (script tự động fallback sang python3.11 nếu `python3` không tồn tại). Khi đăng nhập SSH, kích hoạt sẵn môi trường ảo và chuyển thư mục bằng:
 ```bash
-source /home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11/bin/activate && cd /home/h51ecb951c/domains/hocai.site
+source /home/h51ecb951c/virtualenv/hocai.site/3.11/bin/activate && cd /home/h51ecb951c/domains/hocai.site
 ```
 
 **Cài đặt thủ công:**
 1. Tạo môi trường ảo và cài đặt phụ thuộc (đường dẫn khớp máy chủ đã cấu hình):
    ```bash
-   python3.11 -m venv /home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11
-   source /home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11/bin/activate
+   python3.11 -m venv /home/h51ecb951c/virtualenv/hocai.site/3.11
+   source /home/h51ecb951c/virtualenv/hocai.site/3.11/bin/activate
    pip install -r requirements.txt
    ```
 2. Cấu hình kết nối MariaDB (mặc định dùng thông tin máy chủ nội bộ):
@@ -54,7 +54,7 @@ Kịch bản `deploy.sh` hỗ trợ upload mã nguồn và khởi chạy Gunicor
    export SSH_PORT=2222
    export SSH_USER=root                                # hoặc tài khoản có quyền sudo
    export REMOTE_DIR=/home/h51ecb951c/domains/hocai.site                 # thư mục lưu mã nguồn
-   export VENV_DIR=/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11
+   export VENV_DIR=/home/h51ecb951c/virtualenv/hocai.site/3.11
    export PYTHON_BIN=python3.11                        # khớp cấu hình "Setup Python App 3.11.11"
    export DATABASE_URL="mysql+pymysql://h51ecb951c_hocai:phat2009@localhost/h51ecb951c_hocai?charset=utf8mb4"
    export SECRET_KEY="<chuoi-bi-mat>"
@@ -66,7 +66,7 @@ Kịch bản `deploy.sh` hỗ trợ upload mã nguồn và khởi chạy Gunicor
    ```bash
    ./deploy.sh
    ```
-   Script sẽ đồng bộ mã nguồn bằng `rsync`, cài gói trong môi trường ảo tại `/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11`, khởi tạo bảng CSDL và tạo dịch vụ systemd chạy Gunicorn tại `127.0.0.1:8000`.
+   Script sẽ đồng bộ mã nguồn bằng `rsync`, cài gói trong môi trường ảo tại `/home/h51ecb951c/virtualenv/hocai.site/3.11`, khởi tạo bảng CSDL và tạo dịch vụ systemd chạy Gunicorn tại `127.0.0.1:8000`.
 4. Cấu hình web server (ví dụ LiteSpeed/Apache) reverse proxy `hocai.site` tới `127.0.0.1:8000`, bật HTTPS và HTTP/2 để tận dụng SEO. Với Apache, có thể dùng cấu hình mẫu:
    ```apache
    <VirtualHost *:80>

--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ Website giới thiệu cây thuốc nam và bài thuốc gia truyền của dân
 **Cài đặt nhanh (đã khớp môi trường Setup Python App 3.11.11):**
 ```bash
 chmod +x install.sh
-./install.sh
+bash install.sh   # hoặc ./install.sh nếu có quyền thực thi
 ```
+> Lưu ý: đừng chạy nhầm `pip install install.sh` hoặc đưa file này vào danh sách yêu cầu của pip; pip sẽ coi dòng `set -euo pipefail` là gói và báo lỗi như "Invalid requirement: set -e". Hãy thực thi script bằng Bash.
+
 Script sẽ tạo môi trường ảo tại `/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11` (hoặc dùng lại nếu đã có), cài gói và ghi file `.env` với thông tin miền `hocai.site`, tài khoản quản trị (`admin` / `phat2009`) và kết nối MariaDB mặc định.
-Nếu máy chủ có nhiều phiên bản Python, đặt biến `PYTHON_BIN=python3.11` trước khi chạy để khớp "Setup Python App 3.11.11". Khi đăng nhập SSH, kích hoạt sẵn môi trường ảo và chuyển thư mục bằng:
+Nếu máy chủ có nhiều phiên bản Python, đặt biến `PYTHON_BIN=python3.11` trước khi chạy để khớp "Setup Python App 3.11.11" (script tự động fallback sang python3.11 nếu `python3` không tồn tại). Khi đăng nhập SSH, kích hoạt sẵn môi trường ảo và chuyển thư mục bằng:
 ```bash
 source /home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11/bin/activate && cd /home/h51ecb951c/hocai.site/var/www/hocai
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ bash install.sh   # hoặc ./install.sh nếu có quyền thực thi
 Script sẽ tạo môi trường ảo tại `/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11` (hoặc dùng lại nếu đã có), cài gói và ghi file `.env` với thông tin miền `hocai.site`, tài khoản quản trị (`admin` / `phat2009`) và kết nối MariaDB mặc định.
 Nếu máy chủ có nhiều phiên bản Python, đặt biến `PYTHON_BIN=python3.11` trước khi chạy để khớp "Setup Python App 3.11.11" (script tự động fallback sang python3.11 nếu `python3` không tồn tại). Khi đăng nhập SSH, kích hoạt sẵn môi trường ảo và chuyển thư mục bằng:
 ```bash
-source /home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11/bin/activate && cd /home/h51ecb951c/domains/hocai.site/var/www/hocai
+source /home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11/bin/activate && cd /home/h51ecb951c/domains/hocai.site
 ```
 
 **Cài đặt thủ công:**
@@ -53,7 +53,7 @@ Kịch bản `deploy.sh` hỗ trợ upload mã nguồn và khởi chạy Gunicor
    export SSH_HOST=cda004.secureweb.vn
    export SSH_PORT=2222
    export SSH_USER=root                                # hoặc tài khoản có quyền sudo
-   export REMOTE_DIR=/home/h51ecb951c/domains/hocai.site/var/www/hocai   # thư mục lưu mã nguồn
+   export REMOTE_DIR=/home/h51ecb951c/domains/hocai.site                 # thư mục lưu mã nguồn
    export VENV_DIR=/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11
    export PYTHON_BIN=python3.11                        # khớp cấu hình "Setup Python App 3.11.11"
    export DATABASE_URL="mysql+pymysql://h51ecb951c_hocai:phat2009@localhost/h51ecb951c_hocai?charset=utf8mb4"

--- a/app.py
+++ b/app.py
@@ -1,0 +1,508 @@
+from __future__ import annotations
+
+import json
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, List
+
+from flask import Flask, abort, flash, redirect, render_template, request, session, url_for
+from flask_sqlalchemy import SQLAlchemy
+
+BASE_DIR = Path(__file__).parent
+app = Flask(__name__)
+app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", "thi-en-tam-secret-key")
+app.config["ADMIN_PASSWORD"] = os.getenv("ADMIN_PASSWORD", "tientocham")
+app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv(
+    "DATABASE_URL",
+    "mysql+pymysql://h51ecb951c_hocai:phat2009@localhost/h51ecb951c_hocai?charset=utf8mb4",
+)
+app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {
+    "pool_size": 5,
+    "max_overflow": 2,
+    "pool_recycle": 280,
+    "pool_timeout": 30,
+    "pool_pre_ping": True,
+}
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+server_name = os.getenv("SERVER_NAME")
+if server_name:
+    app.config["SERVER_NAME"] = server_name
+app.config["PREFERRED_URL_SCHEME"] = os.getenv("PREFERRED_URL_SCHEME", "https")
+db = SQLAlchemy(app)
+
+
+def _json_to_list(value: str | None) -> List[str]:
+    try:
+        return json.loads(value or "[]")
+    except json.JSONDecodeError:
+        return []
+
+
+class Topic(db.Model):
+    __tablename__ = "topics"
+
+    id = db.Column(db.Integer, primary_key=True)
+    slug = db.Column(db.String(120), unique=True, nullable=False)
+    title = db.Column(db.String(255), nullable=False)
+    summary = db.Column(db.Text, default="")
+    remedies_json = db.Column(db.Text, default="[]")
+
+    @property
+    def remedies_list(self) -> List[str]:
+        return _json_to_list(self.remedies_json)
+
+    def set_remedies(self, remedies: List[str]) -> None:
+        self.remedies_json = json.dumps(remedies, ensure_ascii=False)
+
+
+class NewsItem(db.Model):
+    __tablename__ = "news_items"
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(255), nullable=False)
+    source = db.Column(db.String(255), default="")
+    url = db.Column(db.Text, nullable=False)
+    summary = db.Column(db.Text, default="")
+
+
+def seed_topics() -> List[Dict]:
+    default_topics: List[Dict] = [
+        {
+            "slug": "soi-than",
+            "title": "Sỏi thận",
+            "summary": "Giải pháp thảo dược giúp giảm đau, bào mòn sỏi và hỗ trợ tiết niệu khỏe mạnh.",
+            "remedies": [
+                "Nước râu ngô, kim tiền thảo đun uống hằng ngày",
+                "Uống đủ nước kết hợp trà rễ cỏ tranh, xa tiền tử",
+                "Xoa bóp vùng hông bằng dầu thảo mộc, giữ ấm cơ thể",
+            ],
+        },
+        {
+            "slug": "viem-cau-than",
+            "title": "Viêm cầu thận",
+            "summary": "Công thức thảo dược gia truyền giảm viêm, lợi tiểu và bảo vệ chức năng lọc của thận.",
+            "remedies": [
+                "Sắc rễ cây muồng trâu, rau má, mã đề uống 2 lần/ngày",
+                "Ăn nhạt, ngủ đủ giấc, tránh rượu bia và giữ ấm thắt lưng",
+                "Xoa bóp day ấn huyệt thận du giúp lưu thông khí huyết",
+            ],
+        },
+        {
+            "slug": "suy-than",
+            "title": "Suy thận",
+            "summary": "Bồi bổ thận khí, hỗ trợ phục hồi sinh lực với thảo dược sạch từ đồng bằng và cao nguyên.",
+            "remedies": [
+                "Chè dây, hoàng kỳ, đương quy sắc uống thay nước",
+                "Chế độ ăn nhiều rau xanh, hạn chế đạm đỏ và thực phẩm chế biến",
+                "Tập thở bụng, thiền nhẹ 15 phút mỗi ngày",
+            ],
+        },
+        {
+            "slug": "viem-tiet-nieu",
+            "title": "Viêm tiết niệu",
+            "summary": "Kháng khuẩn tự nhiên, lợi tiểu và làm mát giúp tiểu tiện dễ chịu, giảm tái phát.",
+            "remedies": [
+                "Rau diếp cá, râu ngô, kim ngân hoa sắc uống",
+                "Uống đủ 2 lít nước/ngày và vệ sinh cá nhân đúng cách",
+                "Tắm lá trầu không, lá tràm dịu nhẹ để giảm ngứa rát",
+            ],
+        },
+        {
+            "slug": "lam-dep-da",
+            "title": "Làm đẹp da",
+            "summary": "Thanh lọc cơ thể, dưỡng huyết và phục hồi làn da sáng khỏe từ thảo dược Chăm.",
+            "remedies": [
+                "Uống trà atiso, trà xanh, cam thảo mỗi sáng",
+                "Đắp mặt nạ nghệ, mật ong và sữa chua 2 lần/tuần",
+                "Ngủ trước 23h, tập yoga nhẹ để giảm stress",
+            ],
+        },
+        {
+            "slug": "viem-khop",
+            "title": "Viêm khớp",
+            "summary": "Giảm đau, kháng viêm, phục hồi vận động với bài thuốc gia truyền của người Chăm.",
+            "remedies": [
+                "Ngâm chân gừng muối ấm, xoa bóp bằng dầu gió thảo mộc",
+                "Uống sắc rễ nhàu, dây đau xương, thiên niên kiện",
+                "Tập kéo giãn khớp, đi bộ nhẹ 20 phút/ngày",
+            ],
+        },
+        {
+            "slug": "thoai-hoa-khop",
+            "title": "Thoái hóa khớp",
+            "summary": "Tăng cường sụn khớp, gim khô cứng với thảo dược ấm và bổ.",
+            "remedies": [
+                "Sắc ngải cứu, lá lốt, thiên niên kiện uống buổi tối",
+                "Chườm thảo dược rang muối nóng vào vùng khớp",
+                "Bổ sung collagen, tập bơi hoặc đạp xe nhẹ",
+            ],
+        },
+        {
+            "slug": "gout",
+            "title": "Gout",
+            "summary": "Kiểm soát acid uric, giảm sưng đau khớp với thảo dược mát và lợi tiểu.",
+            "remedies": [
+                "Trà lá tía tô, râu ngô, ké đầu ngựa uống ấm",
+                "Ăn nhiều rau xanh, giảm thịt đỏ, nội tạng và bia rượu",
+                "Chườm lạnh khớp sưng, nghỉ ngơi khi đau cấp",
+            ],
+        },
+    ]
+
+    for topic in default_topics:
+        model = Topic(slug=topic["slug"], title=topic["title"], summary=topic["summary"])
+        model.set_remedies(topic["remedies"])
+        db.session.add(model)
+    db.session.commit()
+    return default_topics
+
+
+def seed_news() -> List[Dict]:
+    default_news: List[Dict] = [
+        {
+            "title": "5 thảo dược giúp thanh lọc thận an toàn",
+            "source": "Tạp chí Đông y",
+            "url": "https://example.com/thao-duoc-thanh-loc-than",
+            "summary": "Giới thiệu các vị thuốc mát, lợi tiểu và cách sử dụng đúng để bảo vệ thận.",
+        },
+        {
+            "title": "Dân gian chữa sỏi thận bằng kim tiền thảo",
+            "source": "Sức khỏe & Đời sống",
+            "url": "https://example.com/kim-tien-thao-soi-than",
+            "summary": "Cơ chế bào mòn sỏi và cách sắc uống kim tiền thảo chuẩn vị nam dược.",
+        },
+        {
+            "title": "Đông y hỗ trợ viêm cầu thận mạn tính",
+            "source": "Y học cổ truyền",
+            "url": "https://example.com/dong-y-viem-cau-than",
+            "summary": "Phác đồ kết hợp thảo dược lợi tiểu, kháng viêm với chế độ ăn nhạt.",
+        },
+        {
+            "title": "Chăm sóc da tự nhiên với thảo mộc bản địa",
+            "source": "Cộng đồng chăm sóc da",
+            "url": "https://example.com/lam-dep-da-thao-moc",
+            "summary": "Hướng dẫn dùng nghệ, trà xanh và mật ong để dưỡng sáng da an toàn.",
+        },
+        {
+            "title": "Cách ngăn tái phát viêm tiết niệu từ chế độ sinh hoạt",
+            "source": "Sống khỏe",
+            "url": "https://example.com/viem-tiet-nieu-sinh-hoat",
+            "summary": "Các mẹo uống nước, vệ sinh và bài thuốc dân gian giúp giảm nguy cơ tái phát.",
+        },
+        {
+            "title": "Bí quyết người Chăm chăm sóc khớp",
+            "source": "Báo Sức khỏe",
+            "url": "https://example.com/bi-quyet-cham-soc-khop",
+            "summary": "Thực hành xoa bóp, ngâm thảo dược và ẩm thực ấm áp bảo vệ xương khớp.",
+        },
+        {
+            "title": "Điều chỉnh lối sống để kiểm soát gout",
+            "source": "Tư vấn dinh dưỡng",
+            "url": "https://example.com/kiem-soat-gout",
+            "summary": "Giảm đạm động vật, tăng thực vật và kết hợp thảo dược mát để hạ acid uric.",
+        },
+        {
+            "title": "Những dấu hiệu cảnh báo suy thận sớm",
+            "source": "Sức khỏe thận",
+            "url": "https://example.com/dau-hieu-suy-than",
+            "summary": "Phát hiện sớm phù, mệt mỏi và cách hỗ trợ với bài thuốc bổ thận khí.",
+        },
+        {
+            "title": "Thải độc an toàn cho người viêm khớp",
+            "source": "Tạp chí Dinh dưỡng",
+            "url": "https://example.com/thai-doc-viem-khop",
+            "summary": "Công thức nước uống thảo mộc giúp giảm viêm, hỗ trợ chuyển hóa.",
+        },
+        {
+            "title": "3 bước chăm sóc tiết niệu khỏe mạnh hằng ngày",
+            "source": "Mẹo sống khỏe",
+            "url": "https://example.com/cham-soc-tiet-nieu",
+            "summary": "Uống nước đủ, vệ sinh khoa học và thảo dược phòng ngừa viêm nhiễm.",
+        },
+    ]
+
+    for item in default_news:
+        db.session.add(
+            NewsItem(
+                title=item["title"],
+                source=item.get("source", ""),
+                url=item["url"],
+                summary=item.get("summary", ""),
+            )
+        )
+    db.session.commit()
+    return default_news
+
+
+def topic_to_dict(topic: Topic) -> Dict:
+    return {
+        "slug": topic.slug,
+        "title": topic.title,
+        "summary": topic.summary,
+        "remedies": topic.remedies_list,
+    }
+
+
+def news_to_dict(item: NewsItem) -> Dict:
+    return {
+        "id": item.id,
+        "title": item.title,
+        "source": item.source,
+        "url": item.url,
+        "summary": item.summary,
+    }
+
+
+@lru_cache(maxsize=1)
+def _cached_topics() -> List[Dict]:
+    topics = Topic.query.order_by(Topic.title.asc()).all()
+    if not topics:
+        seed_topics()
+        topics = Topic.query.order_by(Topic.title.asc()).all()
+    return [topic_to_dict(topic) for topic in topics]
+
+
+@lru_cache(maxsize=1)
+def _cached_news() -> List[Dict]:
+    news_items = NewsItem.query.order_by(NewsItem.id.desc()).all()
+    if not news_items:
+        seed_news()
+        news_items = NewsItem.query.order_by(NewsItem.id.desc()).all()
+    return [news_to_dict(item) for item in news_items]
+
+
+def refresh_topic_cache() -> List[Dict]:
+    _cached_topics.cache_clear()
+    return _cached_topics()
+
+
+def refresh_news_cache() -> List[Dict]:
+    _cached_news.cache_clear()
+    return _cached_news()
+
+
+def get_topics() -> List[Dict]:
+    return _cached_topics()
+
+
+def get_news(limit: int | None = None) -> List[Dict]:
+    mapped = _cached_news()
+    return mapped[:limit] if limit else mapped
+
+
+def find_topic(slug: str) -> Dict:
+    topic = Topic.query.filter_by(slug=slug).first()
+    if topic:
+        return topic_to_dict(topic)
+    abort(404)
+
+
+def is_admin() -> bool:
+    return session.get("admin", False)
+
+
+def require_admin() -> None:
+    if not is_admin():
+        abort(403)
+
+
+@app.context_processor
+def inject_globals():
+    return {
+        "site_name": "Nhà thuốc Nam Thiên Tâm",
+        "nav_topics": get_topics(),
+    }
+
+
+@app.route("/")
+def home():
+    topics = get_topics()
+    latest_news = get_news(limit=4)
+    return render_template(
+        "home.html",
+        topics=topics,
+        latest_news=latest_news,
+        meta={
+            "title": "Nhà thuốc Nam Thiên Tâm | Bài thuốc Chăm gia truyền",
+            "description": "Bài thuốc nam hỗ trợ sỏi thận, viêm cầu thận, gout, viêm khớp, làm đẹp da và chăm sóc tiết niệu từ dân tộc Chăm.",
+            "canonical": url_for("home", _external=True),
+        },
+    )
+
+
+@app.route("/chu-de/<slug>")
+def topic_detail(slug: str):
+    topic = find_topic(slug)
+    return render_template(
+        "topic.html",
+        topic=topic,
+        meta={
+            "title": f"{topic['title']} | Bài thuốc Nam Thiên Tâm",
+            "description": topic["summary"],
+            "canonical": url_for("topic_detail", slug=slug, _external=True),
+            "breadcrumbs": [
+                {"name": "Trang chủ", "url": url_for("home", _external=True)},
+                {"name": "Chủ đề", "url": url_for("home", _external=True) + "#topics"},
+                {"name": topic["title"], "url": url_for("topic_detail", slug=slug, _external=True)},
+            ],
+        },
+    )
+
+
+@app.route("/tin-tuc")
+def news_list():
+    return render_template(
+        "news.html",
+        news_items=get_news(),
+        meta={
+            "title": "Tin tức Đông y & bài thuốc nam hữu ích",
+            "description": "Tổng hợp tin tức chất lượng về thảo dược, sức khỏe thận, xương khớp và làm đẹp da.",
+            "canonical": url_for("news_list", _external=True),
+        },
+    )
+
+
+@app.route("/admin", methods=["GET", "POST"])
+def admin_dashboard():
+    require_admin()
+    topics = get_topics()
+    news_items = get_news()
+    return render_template("admin/dashboard.html", topics=topics, news_items=news_items)
+
+
+@app.route("/admin/login", methods=["GET", "POST"])
+def admin_login():
+    if request.method == "POST":
+        password = request.form.get("password")
+        if password == app.config["ADMIN_PASSWORD"]:
+            session["admin"] = True
+            flash("Đăng nhập thành công", "success")
+            return redirect(url_for("admin_dashboard"))
+        flash("Mật khẩu chưa đúng", "danger")
+    return render_template("admin/login.html")
+
+
+@app.route("/admin/logout")
+def admin_logout():
+    session.pop("admin", None)
+    flash("Đã đăng xuất", "info")
+    return redirect(url_for("home"))
+
+
+@app.route("/admin/topics", methods=["POST"])
+def admin_add_topic():
+    require_admin()
+    title = request.form.get("title", "").strip()
+    slug = request.form.get("slug", "").strip()
+    summary = request.form.get("summary", "").strip()
+    remedies_text = request.form.get("remedies", "")
+    remedies = [item.strip() for item in remedies_text.split("\n") if item.strip()]
+
+    if not title or not slug:
+        flash("Vui lòng nhập đầy đủ tiêu đề và đường dẫn", "warning")
+        return redirect(url_for("admin_dashboard"))
+
+    if Topic.query.filter_by(slug=slug).first():
+        flash("Đường dẫn đã tồn tại", "danger")
+        return redirect(url_for("admin_dashboard"))
+
+    topic = Topic(title=title, slug=slug, summary=summary)
+    topic.set_remedies(remedies)
+    db.session.add(topic)
+    db.session.commit()
+    refresh_topic_cache()
+
+    flash("Đã thêm chủ đề", "success")
+    return redirect(url_for("admin_dashboard"))
+
+
+@app.route("/admin/topics/<slug>", methods=["POST"])
+def admin_update_topic(slug: str):
+    require_admin()
+    topic = Topic.query.filter_by(slug=slug).first()
+    if not topic:
+        abort(404)
+
+    topic.title = request.form.get("title", topic.title).strip()
+    topic.summary = request.form.get("summary", topic.summary).strip()
+    remedies_text = request.form.get("remedies", "")
+    remedies = [item.strip() for item in remedies_text.split("\n") if item.strip()]
+    if remedies:
+        topic.set_remedies(remedies)
+
+    db.session.commit()
+    refresh_topic_cache()
+    flash("Đã cập nhật chủ đề", "success")
+    return redirect(url_for("admin_dashboard"))
+
+
+@app.route("/admin/topics/<slug>/delete", methods=["POST"])
+def admin_delete_topic(slug: str):
+    require_admin()
+    topic = Topic.query.filter_by(slug=slug).first()
+    if topic:
+        db.session.delete(topic)
+        db.session.commit()
+        refresh_topic_cache()
+        flash("Đã xóa chủ đề", "info")
+    return redirect(url_for("admin_dashboard"))
+
+
+@app.route("/admin/news", methods=["POST"])
+def admin_add_news():
+    require_admin()
+    title = request.form.get("title", "").strip()
+    url_value = request.form.get("url", "").strip()
+    source = request.form.get("source", "").strip()
+    summary = request.form.get("summary", "").strip()
+
+    if not title or not url_value:
+        flash("Tiêu đề và liên kết là bắt buộc", "warning")
+        return redirect(url_for("admin_dashboard"))
+
+    news_item = NewsItem(title=title, url=url_value, source=source, summary=summary)
+    db.session.add(news_item)
+    db.session.commit()
+    refresh_news_cache()
+
+    flash("Đã thêm tin mới", "success")
+    return redirect(url_for("admin_dashboard"))
+
+
+@app.route("/admin/news/<int:item_id>/delete", methods=["POST"])
+def admin_delete_news(item_id: int):
+    require_admin()
+    news_item = NewsItem.query.get(item_id)
+    if news_item:
+        db.session.delete(news_item)
+        db.session.commit()
+        refresh_news_cache()
+        flash("Đã xóa tin", "info")
+    return redirect(url_for("admin_dashboard"))
+
+
+@app.errorhandler(403)
+def forbidden(_):
+    return render_template("errors/403.html"), 403
+
+
+@app.errorhandler(404)
+def not_found(_):
+    return render_template("errors/404.html"), 404
+
+
+def setup_database() -> None:
+    db.create_all()
+    if not Topic.query.first():
+        seed_topics()
+    refresh_topic_cache()
+    if not NewsItem.query.first():
+        seed_news()
+    refresh_news_cache()
+
+
+if __name__ == "__main__":
+    with app.app_context():
+        setup_database()
+    app.run(debug=True, host="0.0.0.0", port=5000)

--- a/app.py
+++ b/app.py
@@ -12,7 +12,8 @@ from flask_sqlalchemy import SQLAlchemy
 BASE_DIR = Path(__file__).parent
 app = Flask(__name__)
 app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", "thi-en-tam-secret-key")
-app.config["ADMIN_PASSWORD"] = os.getenv("ADMIN_PASSWORD", "tientocham")
+app.config["ADMIN_USERNAME"] = os.getenv("ADMIN_USERNAME", "admin")
+app.config["ADMIN_PASSWORD"] = os.getenv("ADMIN_PASSWORD", "phat2009")
 app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv(
     "DATABASE_URL",
     "mysql+pymysql://h51ecb951c_hocai:phat2009@localhost/h51ecb951c_hocai?charset=utf8mb4",
@@ -374,12 +375,16 @@ def admin_dashboard():
 @app.route("/admin/login", methods=["GET", "POST"])
 def admin_login():
     if request.method == "POST":
+        username = request.form.get("username")
         password = request.form.get("password")
-        if password == app.config["ADMIN_PASSWORD"]:
+        if (
+            username == app.config["ADMIN_USERNAME"]
+            and password == app.config["ADMIN_PASSWORD"]
+        ):
             session["admin"] = True
             flash("Đăng nhập thành công", "success")
             return redirect(url_for("admin_dashboard"))
-        flash("Mật khẩu chưa đúng", "danger")
+        flash("Sai tài khoản hoặc mật khẩu", "danger")
     return render_template("admin/login.html")
 
 

--- a/data/news.json
+++ b/data/news.json
@@ -1,0 +1,62 @@
+[
+  {
+    "title": "5 thảo dược giúp thanh lọc thận an toàn",
+    "source": "Tạp chí Đông y",
+    "url": "https://example.com/thao-duoc-thanh-loc-than",
+    "summary": "Giới thiệu các vị thuốc mát, lợi tiểu và cách sử dụng đúng để bảo vệ thận."
+  },
+  {
+    "title": "Dân gian chữa sỏi thận bằng kim tiền thảo",
+    "source": "Sức khỏe & Đời sống",
+    "url": "https://example.com/kim-tien-thao-soi-than",
+    "summary": "Cơ chế bào mòn sỏi và cách sắc uống kim tiền thảo chuẩn vị nam dược."
+  },
+  {
+    "title": "Đông y hỗ trợ viêm cầu thận mạn tính",
+    "source": "Y học cổ truyền",
+    "url": "https://example.com/dong-y-viem-cau-than",
+    "summary": "Phác đồ kết hợp thảo dược lợi tiểu, kháng viêm với chế độ ăn nhạt."
+  },
+  {
+    "title": "Chăm sóc da tự nhiên với thảo mộc bản địa",
+    "source": "Cộng đồng chăm sóc da",
+    "url": "https://example.com/lam-dep-da-thao-moc",
+    "summary": "Hướng dẫn dùng nghệ, trà xanh và mật ong để dưỡng sáng da an toàn."
+  },
+  {
+    "title": "Cách ngăn tái phát viêm tiết niệu từ chế độ sinh hoạt",
+    "source": "Sống khỏe",
+    "url": "https://example.com/viem-tiet-nieu-sinh-hoat",
+    "summary": "Các mẹo uống nước, vệ sinh và bài thuốc dân gian giúp giảm nguy cơ tái phát."
+  },
+  {
+    "title": "Bí quyết người Chăm chăm sóc khớp",
+    "source": "Báo Sức khỏe",
+    "url": "https://example.com/bi-quyet-cham-soc-khop",
+    "summary": "Thực hành xoa bóp, ngâm thảo dược và ẩm thực ấm áp bảo vệ xương khớp."
+  },
+  {
+    "title": "Điều chỉnh lối sống để kiểm soát gout",
+    "source": "Tư vấn dinh dưỡng",
+    "url": "https://example.com/kiem-soat-gout",
+    "summary": "Giảm đạm động vật, tăng thực vật và kết hợp thảo dược mát để hạ acid uric."
+  },
+  {
+    "title": "Những dấu hiệu cảnh báo suy thận sớm",
+    "source": "Sức khỏe thận",
+    "url": "https://example.com/dau-hieu-suy-than",
+    "summary": "Phát hiện sớm phù, mệt mỏi và cách hỗ trợ với bài thuốc bổ thận khí."
+  },
+  {
+    "title": "Thải độc an toàn cho người viêm khớp",
+    "source": "Tạp chí Dinch dưỡng",
+    "url": "https://example.com/thai-doc-viem-khop",
+    "summary": "Công thức nước uống thảo mộc giúp giảm viêm, hỗ trợ chuyển hóa."
+  },
+  {
+    "title": "3 bước chăm sóc tiết niệu khỏe mạnh hằng ngày",
+    "source": "Mẹo sống khỏe",
+    "url": "https://example.com/cham-soc-tiet-nieu",
+    "summary": "Uống nước đủ, vệ sinh khoa học và thảo dược phòng ngừa viêm nhiễm."
+  }
+]

--- a/data/topics.json
+++ b/data/topics.json
@@ -1,0 +1,82 @@
+[
+  {
+    "slug": "soi-than",
+    "title": "Sỏi thận",
+    "summary": "Giải pháp thảo dược giúp giảm đau, bào mòn sỏi và hỗ trợ tiết niệu khỏe mạnh.",
+    "remedies": [
+      "Nước râu ngô, kim tiền thảo đun uống hằng ngày",
+      "Uống đủ nước kết hợp trà rễ cỏ tranh, xa tiền tử",
+      "Xoa bóp vùng hông bằng dầu thảo mộc, giữ ấm cơ thể"
+    ]
+  },
+  {
+    "slug": "viem-cau-than",
+    "title": "Viêm cầu thận",
+    "summary": "Công thức thảo dược gia truyền giảm viêm, lợi tiểu và bảo vệ chức năng lọc của thận.",
+    "remedies": [
+      "Sắc rễ cây muồng trâu, rau má, mã đề uống 2 lần/ngày",
+      "Ăn nhạt, ngủ đủ giấc, tránh rượu bia và giữ ấm thắt lưng",
+      "Xoa bóp day ấn huyệt thận du giúp lưu thông khí huyết"
+    ]
+  },
+  {
+    "slug": "suy-than",
+    "title": "Suy thận",
+    "summary": "Bồi bổ thận khí, hỗ trợ phục hồi sinh lực với thảo dược sạch từ đồng bằng và cao nguyên.",
+    "remedies": [
+      "Chè dây, hoàng kỳ, đương quy sắc uống thay nước",
+      "Chế độ ăn nhiều rau xanh, hạn chế đạm đỏ và thực phẩm chế biến",
+      "Tập thở bụng, thiền nhẹ 15 phút mỗi ngày"
+    ]
+  },
+  {
+    "slug": "viem-tiet-nieu",
+    "title": "Viêm tiết niệu",
+    "summary": "Kháng khuẩn tự nhiên, lợi tiểu và làm mát giúp tiểu tiện dễ chịu, giảm tái phát.",
+    "remedies": [
+      "Rau diếp cá, râu ngô, kim ngân hoa sắc uống",
+      "Uống đủ 2 lít nước/ngày và vệ sinh cá nhân đúng cách",
+      "Tắm lá trầu không, lá tràm dịu nhẹ để giảm ngứa rát"
+    ]
+  },
+  {
+    "slug": "lam-dep-da",
+    "title": "Làm đẹp da",
+    "summary": "Thanh lọc cơ thể, dưỡng huyết và phục hồi làn da sáng khỏe từ thảo dược Chăm.",
+    "remedies": [
+      "Uống trà atiso, trà xanh, cam thảo mỗi sáng",
+      "Đắp mặt nạ nghệ, mật ong và sữa chua 2 lần/tuần",
+      "Ngủ trước 23h, tập yoga nhẹ để giảm stress"
+    ]
+  },
+  {
+    "slug": "viem-khop",
+    "title": "Viêm khớp",
+    "summary": "Giảm đau, kháng viêm, phục hồi vận động với bài thuốc gia truyền của người Chăm.",
+    "remedies": [
+      "Ngâm chân gừng muối ấm, xoa bóp bằng dầu gió thảo mộc",
+      "Uống sắc rễ nhàu, dây đau xương, thiên niên kiện",
+      "Tập kéo giãn khớp, đi bộ nhẹ 20 phút/ngày"
+    ]
+  },
+  {
+    "slug": "thoai-hoa-khop",
+    "title": "Thoái hóa khớp",
+    "summary": "Tăng cường sụn khớp, giảm khô cứng với thảo dược ấm và bổ.",
+    "remedies": [
+      "Sắc ngải cứu, lá lốt, thiên niên kiện uống buổi tối",
+      "Chườm thảo dược rang muối nóng vào vùng khớp",
+      "Bổ sung collagen, tập bơi hoặc đạp xe nhẹ"
+    ]
+  },
+  {
+    "slug": "gout",
+    "title": "Gout",
+    "summary": "Kiểm soát acid uric, giảm sưng đau khớp với thảo dược mát và lợi tiểu.",
+    "remedies": [
+      "Trà lá tía tô, râu ngô, ké đầu ngựa uống ấm",
+      "Ăn nhiều rau xanh, giảm thịt đỏ, nội tạng và bia rượu",
+      "Chườm lạnh khớp sưng, nghỉ ngơi khi đau cấp"
+    ]
+  }
+]

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple deployment helper for hocai.site
+# Required env variables (can be exported before running):
+#   SSH_HOST (default: hocai.site)
+#   SSH_USER (default: root)
+#   REMOTE_DIR (default: /var/www/hocai)
+#   APP_PORT (default: 8000)
+#   SERVICE_NAME (default: hocai-site)
+#   SECRET_KEY, ADMIN_PASSWORD, DATABASE_URL, SERVER_NAME (optional overrides)
+
+SSH_HOST=${SSH_HOST:-hocai.site}
+SSH_USER=${SSH_USER:-root}
+REMOTE_DIR=${REMOTE_DIR:-/var/www/hocai}
+APP_PORT=${APP_PORT:-8000}
+SERVICE_NAME=${SERVICE_NAME:-hocai-site}
+PYTHON_BIN=${PYTHON_BIN:-python3}
+
+printf "Deploying to %s@%s:%s (service: %s)\n" "$SSH_USER" "$SSH_HOST" "$REMOTE_DIR" "$SERVICE_NAME"
+
+# Sync source (excluding virtualenv, git metadata, caches)
+rsync -az --delete \
+  --exclude '.venv' \
+  --exclude '__pycache__' \
+  --exclude '.git' \
+  ./ "${SSH_USER}@${SSH_HOST}:${REMOTE_DIR}"
+
+ssh "${SSH_USER}@${SSH_HOST}" bash <<EOF_REMOTE
+set -euo pipefail
+cd "${REMOTE_DIR}"
+
+# Setup Python env and dependencies
+${PYTHON_BIN} -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# Write runtime environment variables for Flask/Gunicorn
+cat > .env <<ENVFILE
+SECRET_KEY=${SECRET_KEY:-thi-en-tam-secret-key}
+ADMIN_PASSWORD=${ADMIN_PASSWORD:-tientocham}
+DATABASE_URL=${DATABASE_URL:-mysql+pymysql://h51ecb951c_hocai:phat2009@localhost/h51ecb951c_hocai?charset=utf8mb4}
+SERVER_NAME=${SERVER_NAME:-hocai.site}
+PREFERRED_URL_SCHEME=https
+ENVFILE
+
+# Initialize database tables if missing
+set -a
+source .env
+set +a
+python - <<'PYCODE'
+from app import app, setup_database
+with app.app_context():
+    setup_database()
+PYCODE
+
+# Configure systemd service for Gunicorn
+cat >/etc/systemd/system/${SERVICE_NAME}.service <<SERVICE
+[Unit]
+Description=Gunicorn service for hocai.site
+After=network.target
+
+[Service]
+WorkingDirectory=${REMOTE_DIR}
+EnvironmentFile=${REMOTE_DIR}/.env
+ExecStart=${REMOTE_DIR}/.venv/bin/gunicorn --workers 2 --threads 2 --bind 127.0.0.1:${APP_PORT} app:app
+Restart=always
+User=www-data
+Group=www-data
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+systemctl daemon-reload
+systemctl enable --now ${SERVICE_NAME}.service
+EOF_REMOTE

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 # Simple deployment helper for hocai.site
 # Required env variables (can be exported before running):
-#   SSH_HOST (default: hocai.site)
+#   SSH_HOST (default: cda004.secureweb.vn)
+#   SSH_PORT (default: 2222)
 #   SSH_USER (default: root)
 #   REMOTE_DIR (default: /home/h51ecb951c/hocai.site/var/www/hocai)
 #   VENV_DIR (default: /home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11)
@@ -11,7 +12,8 @@ set -euo pipefail
 #   SERVICE_NAME (default: hocai-site)
 #   SECRET_KEY, ADMIN_PASSWORD, DATABASE_URL, SERVER_NAME (optional overrides)
 
-SSH_HOST=${SSH_HOST:-hocai.site}
+SSH_HOST=${SSH_HOST:-cda004.secureweb.vn}
+SSH_PORT=${SSH_PORT:-2222}
 SSH_USER=${SSH_USER:-root}
 REMOTE_DIR=${REMOTE_DIR:-/home/h51ecb951c/hocai.site/var/www/hocai}
 APP_PORT=${APP_PORT:-8000}
@@ -19,19 +21,20 @@ SERVICE_NAME=${SERVICE_NAME:-hocai-site}
 PYTHON_BIN=${PYTHON_BIN:-python3}
 VENV_DIR=${VENV_DIR:-/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11}
 
-printf "Deploying to %s@%s:%s (service: %s)\n" "$SSH_USER" "$SSH_HOST" "$REMOTE_DIR" "$SERVICE_NAME"
+printf "Deploying to %s@%s:%s via port %s (service: %s)\n" "$SSH_USER" "$SSH_HOST" "$REMOTE_DIR" "$SSH_PORT" "$SERVICE_NAME"
 
 # Ensure remote target directory tree exists before syncing
-ssh "${SSH_USER}@${SSH_HOST}" "mkdir -p '${REMOTE_DIR}'"
+ssh -p "${SSH_PORT}" "${SSH_USER}@${SSH_HOST}" "mkdir -p '${REMOTE_DIR}'"
 
 # Sync source (excluding virtualenv, git metadata, caches)
 rsync -az --delete \
   --exclude '.venv' \
   --exclude '__pycache__' \
   --exclude '.git' \
+  -e "ssh -p ${SSH_PORT}" \
   ./ "${SSH_USER}@${SSH_HOST}:${REMOTE_DIR}"
 
-ssh "${SSH_USER}@${SSH_HOST}" bash <<EOF_REMOTE
+ssh -p "${SSH_PORT}" "${SSH_USER}@${SSH_HOST}" bash <<EOF_REMOTE
 set -euo pipefail
 mkdir -p "${REMOTE_DIR}"
 cd "${REMOTE_DIR}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 #   SSH_PORT (default: 2222)
 #   SSH_USER (default: root)
 #   REMOTE_DIR (default: /home/h51ecb951c/domains/hocai.site)
-#   VENV_DIR (default: /home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11)
+#   VENV_DIR (default: /home/h51ecb951c/virtualenv/hocai.site/3.11)
 #   APP_PORT (default: 8000)
 #   SERVICE_NAME (default: hocai-site)
 #   SECRET_KEY, ADMIN_PASSWORD, DATABASE_URL, SERVER_NAME (optional overrides)
@@ -19,7 +19,7 @@ REMOTE_DIR=${REMOTE_DIR:-/home/h51ecb951c/domains/hocai.site}
 APP_PORT=${APP_PORT:-8000}
 SERVICE_NAME=${SERVICE_NAME:-hocai-site}
 PYTHON_BIN=${PYTHON_BIN:-python3}
-VENV_DIR=${VENV_DIR:-/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11}
+VENV_DIR=${VENV_DIR:-/home/h51ecb951c/virtualenv/hocai.site/3.11}
 
 printf "Deploying to %s@%s:%s via port %s (service: %s)\n" "$SSH_USER" "$SSH_HOST" "$REMOTE_DIR" "$SSH_PORT" "$SERVICE_NAME"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -15,7 +15,7 @@ SSH_USER=${SSH_USER:-root}
 REMOTE_DIR=${REMOTE_DIR:-/var/www/hocai}
 APP_PORT=${APP_PORT:-8000}
 SERVICE_NAME=${SERVICE_NAME:-hocai-site}
-PYTHON_BIN=${PYTHON_BIN:-python3}
+PYTHON_BIN=${PYTHON_BIN:-python3.11}
 
 printf "Deploying to %s@%s:%s (service: %s)\n" "$SSH_USER" "$SSH_HOST" "$REMOTE_DIR" "$SERVICE_NAME"
 
@@ -39,7 +39,7 @@ pip install -r requirements.txt
 # Write runtime environment variables for Flask/Gunicorn
 cat > .env <<ENVFILE
 SECRET_KEY=${SECRET_KEY:-thi-en-tam-secret-key}
-ADMIN_PASSWORD=${ADMIN_PASSWORD:-tientocham}
+ADMIN_PASSWORD=${ADMIN_PASSWORD:-phat2009}
 DATABASE_URL=${DATABASE_URL:-mysql+pymysql://h51ecb951c_hocai:phat2009@localhost/h51ecb951c_hocai?charset=utf8mb4}
 SERVER_NAME=${SERVER_NAME:-hocai.site}
 PREFERRED_URL_SCHEME=https

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 #   SSH_HOST (default: cda004.secureweb.vn)
 #   SSH_PORT (default: 2222)
 #   SSH_USER (default: root)
-#   REMOTE_DIR (default: /home/h51ecb951c/domains/hocai.site/var/www/hocai)
+#   REMOTE_DIR (default: /home/h51ecb951c/domains/hocai.site)
 #   VENV_DIR (default: /home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11)
 #   APP_PORT (default: 8000)
 #   SERVICE_NAME (default: hocai-site)
@@ -15,7 +15,7 @@ set -euo pipefail
 SSH_HOST=${SSH_HOST:-cda004.secureweb.vn}
 SSH_PORT=${SSH_PORT:-2222}
 SSH_USER=${SSH_USER:-root}
-REMOTE_DIR=${REMOTE_DIR:-/home/h51ecb951c/domains/hocai.site/var/www/hocai}
+REMOTE_DIR=${REMOTE_DIR:-/home/h51ecb951c/domains/hocai.site}
 APP_PORT=${APP_PORT:-8000}
 SERVICE_NAME=${SERVICE_NAME:-hocai-site}
 PYTHON_BIN=${PYTHON_BIN:-python3}

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 #   SSH_HOST (default: cda004.secureweb.vn)
 #   SSH_PORT (default: 2222)
 #   SSH_USER (default: root)
-#   REMOTE_DIR (default: /home/h51ecb951c/hocai.site/var/www/hocai)
+#   REMOTE_DIR (default: /home/h51ecb951c/domains/hocai.site/var/www/hocai)
 #   VENV_DIR (default: /home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11)
 #   APP_PORT (default: 8000)
 #   SERVICE_NAME (default: hocai-site)
@@ -15,7 +15,7 @@ set -euo pipefail
 SSH_HOST=${SSH_HOST:-cda004.secureweb.vn}
 SSH_PORT=${SSH_PORT:-2222}
 SSH_USER=${SSH_USER:-root}
-REMOTE_DIR=${REMOTE_DIR:-/home/h51ecb951c/hocai.site/var/www/hocai}
+REMOTE_DIR=${REMOTE_DIR:-/home/h51ecb951c/domains/hocai.site/var/www/hocai}
 APP_PORT=${APP_PORT:-8000}
 SERVICE_NAME=${SERVICE_NAME:-hocai-site}
 PYTHON_BIN=${PYTHON_BIN:-python3}

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,17 +5,19 @@ set -euo pipefail
 # Required env variables (can be exported before running):
 #   SSH_HOST (default: hocai.site)
 #   SSH_USER (default: root)
-#   REMOTE_DIR (default: /var/www/hocai)
+#   REMOTE_DIR (default: /home/h51ecb951c/hocai.site/var/www/hocai)
+#   VENV_DIR (default: /home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11)
 #   APP_PORT (default: 8000)
 #   SERVICE_NAME (default: hocai-site)
 #   SECRET_KEY, ADMIN_PASSWORD, DATABASE_URL, SERVER_NAME (optional overrides)
 
 SSH_HOST=${SSH_HOST:-hocai.site}
 SSH_USER=${SSH_USER:-root}
-REMOTE_DIR=${REMOTE_DIR:-/var/www/hocai}
+REMOTE_DIR=${REMOTE_DIR:-/home/h51ecb951c/hocai.site/var/www/hocai}
 APP_PORT=${APP_PORT:-8000}
 SERVICE_NAME=${SERVICE_NAME:-hocai-site}
 PYTHON_BIN=${PYTHON_BIN:-python3.11}
+VENV_DIR=${VENV_DIR:-/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11}
 
 printf "Deploying to %s@%s:%s (service: %s)\n" "$SSH_USER" "$SSH_HOST" "$REMOTE_DIR" "$SERVICE_NAME"
 
@@ -28,11 +30,15 @@ rsync -az --delete \
 
 ssh "${SSH_USER}@${SSH_HOST}" bash <<EOF_REMOTE
 set -euo pipefail
+mkdir -p "${REMOTE_DIR}"
 cd "${REMOTE_DIR}"
 
 # Setup Python env and dependencies
-${PYTHON_BIN} -m venv .venv
-source .venv/bin/activate
+mkdir -p "${VENV_DIR%/*}"
+if [ ! -d "$VENV_DIR" ]; then
+  ${PYTHON_BIN} -m venv "$VENV_DIR"
+fi
+source "$VENV_DIR/bin/activate"
 pip install --upgrade pip
 pip install -r requirements.txt
 
@@ -64,7 +70,7 @@ After=network.target
 [Service]
 WorkingDirectory=${REMOTE_DIR}
 EnvironmentFile=${REMOTE_DIR}/.env
-ExecStart=${REMOTE_DIR}/.venv/bin/gunicorn --workers 2 --threads 2 --bind 127.0.0.1:${APP_PORT} app:app
+ExecStart=${VENV_DIR}/bin/gunicorn --workers 2 --threads 2 --bind 127.0.0.1:${APP_PORT} app:app
 Restart=always
 User=www-data
 Group=www-data

--- a/deploy.sh
+++ b/deploy.sh
@@ -16,7 +16,7 @@ SSH_USER=${SSH_USER:-root}
 REMOTE_DIR=${REMOTE_DIR:-/home/h51ecb951c/hocai.site/var/www/hocai}
 APP_PORT=${APP_PORT:-8000}
 SERVICE_NAME=${SERVICE_NAME:-hocai-site}
-PYTHON_BIN=${PYTHON_BIN:-python3.11}
+PYTHON_BIN=${PYTHON_BIN:-python3}
 VENV_DIR=${VENV_DIR:-/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11}
 
 printf "Deploying to %s@%s:%s (service: %s)\n" "$SSH_USER" "$SSH_HOST" "$REMOTE_DIR" "$SERVICE_NAME"

--- a/deploy.sh
+++ b/deploy.sh
@@ -21,6 +21,9 @@ VENV_DIR=${VENV_DIR:-/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11}
 
 printf "Deploying to %s@%s:%s (service: %s)\n" "$SSH_USER" "$SSH_HOST" "$REMOTE_DIR" "$SERVICE_NAME"
 
+# Ensure remote target directory tree exists before syncing
+ssh "${SSH_USER}@${SSH_HOST}" "mkdir -p '${REMOTE_DIR}'"
+
 # Sync source (excluding virtualenv, git metadata, caches)
 rsync -az --delete \
   --exclude '.venv' \

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,27 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Simple deployment helper for hocai.site
+# LiteSpeed-friendly deployment helper for hocai.site
 # Required env variables (can be exported before running):
 #   SSH_HOST (default: cda004.secureweb.vn)
 #   SSH_PORT (default: 2222)
-#   SSH_USER (default: root)
+#   SSH_USER (default: h51ecb951c)
 #   REMOTE_DIR (default: /home/h51ecb951c/domains/hocai.site)
 #   VENV_DIR (default: /home/h51ecb951c/virtualenv/hocai.site/3.11)
 #   APP_PORT (default: 8000)
-#   SERVICE_NAME (default: hocai-site)
-#   SECRET_KEY, ADMIN_PASSWORD, DATABASE_URL, SERVER_NAME (optional overrides)
+#   SECRET_KEY, ADMIN_USERNAME, ADMIN_PASSWORD, DATABASE_URL, SERVER_NAME (optional overrides)
 
 SSH_HOST=${SSH_HOST:-cda004.secureweb.vn}
 SSH_PORT=${SSH_PORT:-2222}
-SSH_USER=${SSH_USER:-root}
+SSH_USER=${SSH_USER:-h51ecb951c}
 REMOTE_DIR=${REMOTE_DIR:-/home/h51ecb951c/domains/hocai.site}
 APP_PORT=${APP_PORT:-8000}
-SERVICE_NAME=${SERVICE_NAME:-hocai-site}
 PYTHON_BIN=${PYTHON_BIN:-python3}
 VENV_DIR=${VENV_DIR:-/home/h51ecb951c/virtualenv/hocai.site/3.11}
+ENV_FILE=${ENV_FILE:-${REMOTE_DIR}/.env}
+RESTART_FILE=${RESTART_FILE:-${REMOTE_DIR}/tmp/restart.txt}
 
-printf "Deploying to %s@%s:%s via port %s (service: %s)\n" "$SSH_USER" "$SSH_HOST" "$REMOTE_DIR" "$SSH_PORT" "$SERVICE_NAME"
+printf "Deploying to %s@%s:%s via port %s (LiteSpeed mode)\n" "$SSH_USER" "$SSH_HOST" "$REMOTE_DIR" "$SSH_PORT"
 
 # Ensure remote target directory tree exists before syncing
 ssh -p "${SSH_PORT}" "${SSH_USER}@${SSH_HOST}" "mkdir -p '${REMOTE_DIR}'"
@@ -42,49 +42,34 @@ cd "${REMOTE_DIR}"
 # Setup Python env and dependencies
 mkdir -p "${VENV_DIR%/*}"
 if [ ! -d "$VENV_DIR" ]; then
-  ${PYTHON_BIN} -m venv "$VENV_DIR"
+  "${PYTHON_BIN}" -m venv "$VENV_DIR"
 fi
 source "$VENV_DIR/bin/activate"
-pip install --upgrade pip
-pip install -r requirements.txt
+"$VENV_DIR/bin/pip" install --upgrade pip
+"$VENV_DIR/bin/pip" install -r requirements.txt
 
-# Write runtime environment variables for Flask/Gunicorn
-cat > .env <<ENVFILE
+# Write runtime environment variables for Flask
+cat > "${ENV_FILE}" <<ENVFILE
 SECRET_KEY=${SECRET_KEY:-thi-en-tam-secret-key}
+ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
 ADMIN_PASSWORD=${ADMIN_PASSWORD:-phat2009}
 DATABASE_URL=${DATABASE_URL:-mysql+pymysql://h51ecb951c_hocai:phat2009@localhost/h51ecb951c_hocai?charset=utf8mb4}
 SERVER_NAME=${SERVER_NAME:-hocai.site}
-PREFERRED_URL_SCHEME=https
+PREFERRED_URL_SCHEME=${PREFERRED_URL_SCHEME:-https}
+APP_PORT=${APP_PORT}
 ENVFILE
 
 # Initialize database tables if missing
 set -a
-source .env
+source "${ENV_FILE}"
 set +a
-python - <<'PYCODE'
+"$VENV_DIR/bin/python" - <<'PYCODE'
 from app import app, setup_database
 with app.app_context():
     setup_database()
 PYCODE
 
-# Configure systemd service for Gunicorn
-cat >/etc/systemd/system/${SERVICE_NAME}.service <<SERVICE
-[Unit]
-Description=Gunicorn service for hocai.site
-After=network.target
-
-[Service]
-WorkingDirectory=${REMOTE_DIR}
-EnvironmentFile=${REMOTE_DIR}/.env
-ExecStart=${VENV_DIR}/bin/gunicorn --workers 2 --threads 2 --bind 127.0.0.1:${APP_PORT} app:app
-Restart=always
-User=www-data
-Group=www-data
-
-[Install]
-WantedBy=multi-user.target
-SERVICE
-
-systemctl daemon-reload
-systemctl enable --now ${SERVICE_NAME}.service
+# Trigger LiteSpeed/Passenger reload (harmless if unused)
+mkdir -p "$(dirname "${RESTART_FILE}")"
+touch "${RESTART_FILE}"
 EOF_REMOTE

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # It provisions a Python virtual environment, installs dependencies, and writes
 # environment defaults for domain and admin access.
 
-APP_DIR=${APP_DIR:-"/home/h51ecb951c/hocai.site/var/www/hocai"}
+APP_DIR=${APP_DIR:-"/home/h51ecb951c/domains/hocai.site/var/www/hocai"}
 PYTHON_BIN=${PYTHON_BIN:-python3}
 VENV_DIR=${VENV_DIR:-"/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11"}
 ENV_FILE="$APP_DIR/.env"

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # environment defaults for domain and admin access.
 
 APP_DIR=${APP_DIR:-"$HOME/hocai"}
-PYTHON_BIN=${PYTHON_BIN:-python3}
+PYTHON_BIN=${PYTHON_BIN:-python3.11}
 VENV_DIR="$APP_DIR/.venv"
 ENV_FILE="$APP_DIR/.env"
 
@@ -15,7 +15,7 @@ cd "$APP_DIR"
 
 # Create virtual environment if missing
 if [ ! -d "$VENV_DIR" ]; then
-  echo "[+] Creating virtualenv at $VENV_DIR"
+  echo "[+] Creating virtualenv at $VENV_DIR (using $PYTHON_BIN)"
   $PYTHON_BIN -m venv "$VENV_DIR"
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Basic installer for deploying the hocai.site Flask app on a LiteSpeed-compatible host.
+# It provisions a Python virtual environment, installs dependencies, and writes
+# environment defaults for domain and admin access.
+
+APP_DIR=${APP_DIR:-"$HOME/hocai"}
+PYTHON_BIN=${PYTHON_BIN:-python3}
+VENV_DIR="$APP_DIR/.venv"
+ENV_FILE="$APP_DIR/.env"
+
+mkdir -p "$APP_DIR"
+cd "$APP_DIR"
+
+# Create virtual environment if missing
+if [ ! -d "$VENV_DIR" ]; then
+  echo "[+] Creating virtualenv at $VENV_DIR"
+  $PYTHON_BIN -m venv "$VENV_DIR"
+fi
+
+source "$VENV_DIR/bin/activate"
+
+# Install Python dependencies
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# Write default environment values for hocai.site deployment
+cat > "$ENV_FILE" <<'ENVVARS'
+# Flask secret key
+SECRET_KEY=${SECRET_KEY:-"thi-en-tam-secret-key"}
+
+# Admin credentials
+ADMIN_USERNAME=${ADMIN_USERNAME:-"admin"}
+ADMIN_PASSWORD=${ADMIN_PASSWORD:-"phat2009"}
+
+# Database connection
+DATABASE_URL=${DATABASE_URL:-"mysql+pymysql://h51ecb951c_hocai:phat2009@localhost/h51ecb951c_hocai?charset=utf8mb4"}
+
+# Domain configuration
+SERVER_NAME=${SERVER_NAME:-"hocai.site"}
+PREFERRED_URL_SCHEME=${PREFERRED_URL_SCHEME:-"https"}
+ENVVARS
+
+echo "[+] Environment written to $ENV_FILE"
+echo "[✓] Installation complete. Start the app with:"
+echo "    source $VENV_DIR/bin/activate && flask --app app run --host 0.0.0.0 --port 8000"

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # It provisions a Python virtual environment, installs dependencies, and writes
 # environment defaults for domain and admin access.
 
-APP_DIR=${APP_DIR:-"/home/h51ecb951c/domains/hocai.site/var/www/hocai"}
+APP_DIR=${APP_DIR:-"/home/h51ecb951c/domains/hocai.site"}
 PYTHON_BIN=${PYTHON_BIN:-python3}
 VENV_DIR=${VENV_DIR:-"/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11"}
 ENV_FILE="$APP_DIR/.env"

--- a/install.sh
+++ b/install.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 # It provisions a Python virtual environment, installs dependencies, and writes
 # environment defaults for domain and admin access.
 
-APP_DIR=${APP_DIR:-"$HOME/hocai"}
+APP_DIR=${APP_DIR:-"/home/h51ecb951c/hocai.site/var/www/hocai"}
 PYTHON_BIN=${PYTHON_BIN:-python3.11}
-VENV_DIR="$APP_DIR/.venv"
+VENV_DIR=${VENV_DIR:-"/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11"}
 ENV_FILE="$APP_DIR/.env"
 
 mkdir -p "$APP_DIR"
@@ -16,6 +16,7 @@ cd "$APP_DIR"
 # Create virtual environment if missing
 if [ ! -d "$VENV_DIR" ]; then
   echo "[+] Creating virtualenv at $VENV_DIR (using $PYTHON_BIN)"
+  mkdir -p "$(dirname "$VENV_DIR")"
   $PYTHON_BIN -m venv "$VENV_DIR"
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 APP_DIR=${APP_DIR:-"/home/h51ecb951c/domains/hocai.site"}
 PYTHON_BIN=${PYTHON_BIN:-python3}
-VENV_DIR=${VENV_DIR:-"/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11"}
+VENV_DIR=${VENV_DIR:-"/home/h51ecb951c/virtualenv/hocai.site/3.11"}
 ENV_FILE="$APP_DIR/.env"
 
 # Provide a graceful fallback if python3.11 is available but python3 points elsewhere

--- a/install.sh
+++ b/install.sh
@@ -6,12 +6,23 @@ set -euo pipefail
 # environment defaults for domain and admin access.
 
 APP_DIR=${APP_DIR:-"/home/h51ecb951c/hocai.site/var/www/hocai"}
-PYTHON_BIN=${PYTHON_BIN:-python3.11}
+PYTHON_BIN=${PYTHON_BIN:-python3}
 VENV_DIR=${VENV_DIR:-"/home/h51ecb951c/virtualenv/hocai.site/var/www/hocai/3.11"}
 ENV_FILE="$APP_DIR/.env"
 
+# Provide a graceful fallback if python3.11 is available but python3 points elsewhere
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1 && command -v python3.11 >/dev/null 2>&1; then
+  echo "[!] $PYTHON_BIN not found, falling back to python3.11"
+  PYTHON_BIN=python3.11
+fi
+
 mkdir -p "$APP_DIR"
 cd "$APP_DIR"
+
+if [ ! -f requirements.txt ]; then
+  echo "[!] Không tìm thấy requirements.txt trong $APP_DIR. Hãy tải mã nguồn dự án về thư mục này rồi chạy lại." >&2
+  exit 1
+fi
 
 # Create virtual environment if missing
 if [ ! -d "$VENV_DIR" ]; then
@@ -23,8 +34,8 @@ fi
 source "$VENV_DIR/bin/activate"
 
 # Install Python dependencies
-pip install --upgrade pip
-pip install -r requirements.txt
+"$PYTHON_BIN" -m pip install --upgrade pip
+"$PYTHON_BIN" -m pip install -r requirements.txt
 
 # Write default environment values for hocai.site deployment
 cat > "$ENV_FILE" <<'ENVVARS'

--- a/passenger_wsgi.py
+++ b/passenger_wsgi.py
@@ -1,0 +1,4 @@
+"""Passenger entrypoint for LiteSpeed/Setup Python App."""
+
+from app import app as application
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask>=2.3,<3.0
+Flask-SQLAlchemy>=3.1.1
+PyMySQL>=1.1.0
+gunicorn>=21.2.0

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,95 @@
+:root {
+  --green-primary: #0f7b4d;
+  --green-light: #e8f5ef;
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  line-height: 1.6;
+}
+
+.navbar-brand {
+  letter-spacing: 0.4px;
+}
+
+.card h3, .card h2, .card h5 {
+  color: var(--green-primary);
+}
+
+.hero-intro h1 {
+  font-size: clamp(1.8rem, 2.5vw + 1rem, 2.8rem);
+}
+
+.hero-intro p {
+  font-size: 1rem;
+  color: #4a5568;
+}
+
+.feature-bullets li {
+  padding-left: 0.25rem;
+}
+
+.bg-success-subtle {
+  background-color: var(--green-light) !important;
+}
+
+a {
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.btn-success,
+.btn-outline-success:hover,
+.navbar-dark .navbar-nav .nav-link.active {
+  background-color: var(--green-primary);
+  border-color: var(--green-primary);
+}
+
+.btn-outline-success {
+  color: var(--green-primary);
+  border-color: var(--green-primary);
+}
+
+.section-header {
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.section-header .btn-link {
+  padding-left: 0;
+  color: var(--green-primary);
+}
+
+.card-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.card-grid.two-col {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.card-grid.three-col {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+@media (max-width: 575px) {
+  .navbar-brand {
+    font-size: 1rem;
+  }
+
+  .card {
+    border-radius: 0.75rem;
+  }
+
+  .card-body {
+    padding: 1.1rem;
+  }
+}
+
+footer {
+  margin-top: auto;
+}

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -1,0 +1,129 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <div>
+    <p class="text-uppercase text-success small fw-semibold mb-1">Quản trị</p>
+    <h1 class="h4 mb-0">SEO Dashboard</h1>
+    <p class="text-muted mb-0">Cập nhật nội dung, bài thuốc và tin tức để tối ưu tìm kiếm.</p>
+  </div>
+  <a class="btn btn-outline-success" href="{{ url_for('home') }}">Xem trang ngoài</a>
+</div>
+
+<div class="row g-4">
+  <div class="col-lg-6">
+    <div class="card shadow-sm border-0 h-100">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+          <div>
+            <p class="text-success small text-uppercase fw-semibold mb-1">Chủ đề</p>
+            <h2 class="h5 mb-0">Bài thuốc nam</h2>
+          </div>
+          <span class="badge bg-success-subtle text-success">{{ topics|length }} mục</span>
+        </div>
+        <form method="post" action="{{ url_for('admin_add_topic') }}" class="mb-4">
+          <div class="row g-2">
+            <div class="col-md-6">
+              <label class="form-label small">Tiêu đề</label>
+              <input class="form-control" name="title" required>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label small">Slug (không dấu)</label>
+              <input class="form-control" name="slug" required>
+            </div>
+            <div class="col-12">
+              <label class="form-label small">Tóm tắt</label>
+              <textarea class="form-control" name="summary" rows="2"></textarea>
+            </div>
+            <div class="col-12">
+              <label class="form-label small">Các bước/thuốc (mỗi dòng một ý)</label>
+              <textarea class="form-control" name="remedies" rows="3"></textarea>
+            </div>
+          </div>
+          <button class="btn btn-success mt-3" type="submit">Thêm chủ đề</button>
+        </form>
+
+        <div class="list-group">
+          {% for topic in topics %}
+          <div class="list-group-item list-group-item-action">
+            <div class="d-flex justify-content-between align-items-center">
+              <div>
+                <h3 class="h6 mb-1">{{ topic.title }}</h3>
+                <p class="small text-muted mb-2">{{ topic.summary }}</p>
+              </div>
+              <form method="post" action="{{ url_for('admin_delete_topic', slug=topic.slug) }}" onsubmit="return confirm('Xóa chủ đề?');">
+                <button class="btn btn-outline-danger btn-sm">Xóa</button>
+              </form>
+            </div>
+            <form class="mt-2" method="post" action="{{ url_for('admin_update_topic', slug=topic.slug) }}">
+              <div class="row g-2">
+                <div class="col-md-6">
+                  <input class="form-control form-control-sm" name="title" value="{{ topic.title }}">
+                </div>
+                <div class="col-md-6">
+                  <input class="form-control form-control-sm" name="summary" value="{{ topic.summary }}">
+                </div>
+                <div class="col-12">
+                  <textarea class="form-control form-control-sm" name="remedies" rows="2">{{ topic.remedies | join('\n') }}</textarea>
+                </div>
+              </div>
+              <button class="btn btn-outline-success btn-sm mt-2" type="submit">Lưu</button>
+            </form>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-lg-6">
+    <div class="card shadow-sm border-0 h-100">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+          <div>
+            <p class="text-success small text-uppercase fw-semibold mb-1">Tin tức</p>
+            <h2 class="h5 mb-0">Tự động chọn lọc</h2>
+          </div>
+          <span class="badge bg-success-subtle text-success">{{ news_items|length }} bài</span>
+        </div>
+        <form method="post" action="{{ url_for('admin_add_news') }}" class="mb-4">
+          <div class="row g-2">
+            <div class="col-12">
+              <label class="form-label small">Tiêu đề</label>
+              <input class="form-control" name="title" required>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label small">Nguồn</label>
+              <input class="form-control" name="source">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label small">Liên kết</label>
+              <input class="form-control" name="url" required>
+            </div>
+            <div class="col-12">
+              <label class="form-label small">Tóm tắt</label>
+              <textarea class="form-control" name="summary" rows="2"></textarea>
+            </div>
+          </div>
+          <button class="btn btn-success mt-3" type="submit">Thêm tin</button>
+        </form>
+
+        <div class="list-group">
+          {% for item in news_items %}
+          <div class="list-group-item list-group-item-action d-flex justify-content-between align-items-start">
+            <div class="me-3">
+              <h3 class="h6 mb-1">{{ item.title }}</h3>
+              <p class="small text-muted mb-1">Nguồn: {{ item.source }}</p>
+              <p class="small text-secondary mb-2">{{ item.summary }}</p>
+              <a class="small" href="{{ item.url }}" target="_blank" rel="noopener">Đọc liên kết</a>
+            </div>
+            <form method="post" action="{{ url_for('admin_delete_news', item_id=item.id) }}" onsubmit="return confirm('Xóa tin này?');">
+              <button class="btn btn-outline-danger btn-sm">Xóa</button>
+            </form>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-5">
+    <div class="card shadow-sm border-0">
+      <div class="card-body">
+        <h1 class="h5 text-success mb-3">Đăng nhập quản trị</h1>
+        <form method="post">
+          <div class="mb-3">
+            <label class="form-label" for="password">Mật khẩu</label>
+            <input type="password" class="form-control" id="password" name="password" required>
+          </div>
+          <button class="btn btn-success w-100" type="submit">Đăng nhập</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -7,8 +7,12 @@
         <h1 class="h5 text-success mb-3">Đăng nhập quản trị</h1>
         <form method="post">
           <div class="mb-3">
+            <label class="form-label" for="username">Tài khoản</label>
+            <input type="text" class="form-control" id="username" name="username" value="admin" required>
+          </div>
+          <div class="mb-3">
             <label class="form-label" for="password">Mật khẩu</label>
-            <input type="password" class="form-control" id="password" name="password" required>
+            <input type="password" class="form-control" id="password" name="password" value="phat2009" required>
           </div>
           <button class="btn btn-success w-100" type="submit">Đăng nhập</button>
         </form>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="vi">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="index,follow">
+  <meta name="theme-color" content="#0f7b4d">
+  <title>{{ meta.title if meta else site_name }}</title>
+  <meta name="description" content="{{ meta.description if meta else 'Thuốc nam gia truyền chăm sóc thận, khớp và làn da khỏe đẹp.' }}">
+  {% if meta and meta.canonical %}<link rel="canonical" href="{{ meta.canonical }}">{% endif %}
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="{{ meta.title if meta else site_name }}">
+  <meta property="og:description" content="{{ meta.description if meta else 'Thuốc nam gia truyền chăm sóc thận, khớp và làn da khỏe đẹp.' }}">
+  <meta property="og:site_name" content="{{ site_name }}">
+  <meta property="og:locale" content="vi_VN">
+  <meta property="og:url" content="{{ meta.canonical if meta and meta.canonical else request.url }}">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{{ meta.title if meta else site_name }}">
+  <meta name="twitter:description" content="{{ meta.description if meta else 'Thuốc nam gia truyền chăm sóc thận, khớp và làn da khỏe đẹp.' }}">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/css/bootstrap.min.css" integrity="sha512-M4oP/S+uvkfg9VdA+wdG3fHtuPSnENoTTp3WgYi8UxNblE5jfxgWOr1Gi1n6oJh2raXIiQunlslqY5T2CqF0Qg==" crossorigin="anonymous" referrerpolicy="no-referrer">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "{{ site_name }}",
+      "url": "{{ url_for('home', _external=True) }}",
+      "contactPoint": [
+        {
+          "@type": "ContactPoint",
+          "contactType": "customer support",
+          "telephone": "+84-900-123-456",
+          "areaServed": "VN",
+          "availableLanguage": ["vi"]
+        }
+      ]
+    }
+  </script>
+  {% if meta and meta.breadcrumbs %}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {% for crumb in meta.breadcrumbs %}
+        {
+          "@type": "ListItem",
+          "position": {{ loop.index }},
+          "name": "{{ crumb.name }}",
+          "item": "{{ crumb.url }}"
+        }{% if not loop.last %},{% endif %}
+        {% endfor %}
+      ]
+    }
+  </script>
+  {% endif %}
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-expand-lg navbar-dark bg-success shadow-sm">
+  <div class="container">
+    <a class="navbar-brand fw-bold" href="{{ url_for('home') }}">{{ site_name }}</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav me-auto">
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('home') }}">Trang chủ</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('news_list') }}">Tin tức</a></li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="topicsDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Chủ đề</a>
+          <ul class="dropdown-menu">
+            {% for topic in nav_topics %}
+            <li><a class="dropdown-item" href="{{ url_for('topic_detail', slug=topic.slug) }}">{{ topic.title }}</a></li>
+            {% endfor %}
+          </ul>
+        </li>
+      </ul>
+      <div class="d-flex align-items-center gap-2">
+        {% if session.get('admin') %}
+          <a class="btn btn-light btn-sm" href="{{ url_for('admin_dashboard') }}">Quản trị</a>
+          <a class="btn btn-outline-light btn-sm" href="{{ url_for('admin_logout') }}">Đăng xuất</a>
+        {% else %}
+          <a class="btn btn-outline-light btn-sm" href="{{ url_for('admin_login') }}">Đăng nhập</a>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</nav>
+
+<main class="py-4">
+  <div class="container">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        <div class="mb-3">
+          {% for category, message in messages %}
+            <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+              {{ message }}
+              <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+  </div>
+</main>
+
+<footer class="bg-dark text-white py-4 mt-auto">
+  <div class="container text-center">
+    <p class="mb-1 fw-bold">{{ site_name }} - Thuốc gia truyền dân tộc Chăm</p>
+    <p class="mb-0 small">Tư vấn chuyên môn: 08:00 - 20:00 | Hotline: 0900 123 456</p>
+  </div>
+</footer>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.bundle.min.js" integrity="sha512-I6rjVnqk6IyQ3cTUaDSJPFmN2kLBXjg5eQof8I4eAbOeXtfLOcOfeUeawuO/7dBDEuDfSU/EYEYVplpXglVvjA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+</body>
+</html>

--- a/templates/errors/403.html
+++ b/templates/errors/403.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="text-center py-5">
+  <h1 class="display-5 text-success">403</h1>
+  <p class="lead">Bạn cần đăng nhập để truy cập khu vực quản trị.</p>
+  <a class="btn btn-success" href="{{ url_for('admin_login') }}">Đăng nhập</a>
+</div>
+{% endblock %}

--- a/templates/errors/404.html
+++ b/templates/errors/404.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="text-center py-5">
+  <h1 class="display-5 text-success">404</h1>
+  <p class="lead">Trang bạn tìm không tồn tại hoặc đã được di chuyển.</p>
+  <a class="btn btn-success" href="{{ url_for('home') }}">Về trang chủ</a>
+</div>
+{% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,67 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="mb-5 hero-intro">
+  <div class="row align-items-center gy-4">
+    <div class="col-lg-6">
+      <h1 class="fw-bold text-success mb-3">Bài thuốc nam gia truyền Thiên Tâm</h1>
+      <p class="mb-4">Đội ngũ lương y dân tộc Chăm, đồng hành cùng bạn trong hành trình chăm sóc thận, tiết niệu, xương khớp và làn da khỏe mạnh.</p>
+      <div class="d-flex flex-wrap gap-2">
+        <a class="btn btn-success" href="#topics">Khám phá chủ đề</a>
+        <a class="btn btn-outline-success" href="{{ url_for('news_list') }}">Xem tin tức</a>
+      </div>
+    </div>
+    <div class="col-lg-6">
+      <div class="card shadow-sm border-0 h-100">
+        <div class="card-body">
+          <h2 class="h5 text-success mb-3">Cam kết chất lượng</h2>
+          <ul class="list-unstyled mb-0 feature-bullets">
+            <li class="mb-2">✔️ Thảo dược sạch, thu hái tại vùng nguyên liệu chuẩn hữu cơ</li>
+            <li class="mb-2">✔️ Công thức gia truyền, phù hợp thể trạng người Việt</li>
+            <li class="mb-2">✔️ Hướng dẫn sử dụng rõ ràng, hỗ trợ tư vấn miễn phí</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="topics" class="mb-5">
+  <div class="d-flex justify-content-between align-items-center section-header mb-3">
+    <h2 class="h4 mb-0 text-success">Chủ đề nổi bật</h2>
+    <a class="btn btn-link" href="#topics">Tất cả 8 chủ đề</a>
+  </div>
+  <div class="card-grid two-col">
+    {% for topic in topics %}
+    <div>
+      <div class="card h-100 shadow-sm border-0">
+        <div class="card-body d-flex flex-column">
+          <h3 class="h5 text-success">{{ topic.title }}</h3>
+          <p class="text-muted flex-grow-1">{{ topic.summary }}</p>
+          <a class="btn btn-outline-success mt-2" href="{{ url_for('topic_detail', slug=topic.slug) }}">Xem bài thuốc</a>
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+
+<section class="mb-4">
+  <div class="d-flex justify-content-between align-items-center section-header mb-3">
+    <h2 class="h4 mb-0 text-success">Tin tức & kiến thức</h2>
+    <a class="btn btn-link" href="{{ url_for('news_list') }}">Xem tất cả</a>
+  </div>
+  <div class="card-grid three-col">
+    {% for item in latest_news %}
+    <div>
+      <div class="card h-100 border-0 shadow-sm">
+        <div class="card-body d-flex flex-column">
+          <h3 class="h6 text-success">{{ item.title }}</h3>
+          <p class="small text-muted flex-grow-1">{{ item.summary }}</p>
+          <a class="stretched-link" href="{{ item.url }}" target="_blank" rel="noopener">Nguồn: {{ item.source }}</a>
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+{% endblock %}

--- a/templates/news.html
+++ b/templates/news.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="mb-4">
+  <div class="d-flex justify-content-between align-items-center section-header mb-3">
+    <div>
+      <p class="text-uppercase text-success fw-semibold small mb-1">Tin tức</p>
+      <h1 class="h3">Tin tức Đông y & sức khỏe</h1>
+      <p class="text-muted mb-0">Tự động tổng hợp 10 bài viết chất lượng, hữu ích cho mọi người.</p>
+    </div>
+    <a class="btn btn-outline-success" href="{{ url_for('admin_login') }}">Đóng góp tin</a>
+  </div>
+  <div class="card-grid two-col">
+    {% for item in news_items %}
+    <div>
+      <div class="card h-100 border-0 shadow-sm">
+        <div class="card-body d-flex flex-column">
+          <div class="d-flex justify-content-between align-items-start">
+            <h2 class="h5 text-success">{{ item.title }}</h2>
+            <span class="badge bg-success-subtle text-success">{{ loop.index }}/10</span>
+          </div>
+          <p class="text-muted flex-grow-1">{{ item.summary }}</p>
+          <p class="small text-secondary mb-2">Nguồn: {{ item.source }}</p>
+          <a class="btn btn-outline-success mt-auto" href="{{ item.url }}" target="_blank" rel="noopener">Đọc bài viết</a>
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+{% endblock %}

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block content %}
+<article class="mb-4">
+  <header class="mb-3">
+    <p class="text-uppercase text-success fw-semibold small">Chủ đề</p>
+    <h1 class="h3 text-dark">{{ topic.title }}</h1>
+    <p class="text-muted">{{ topic.summary }}</p>
+  </header>
+  <section class="card border-0 shadow-sm">
+    <div class="card-body">
+      <h2 class="h5 text-success">Bài thuốc gợi ý</h2>
+      <ol class="mt-3 mb-0">
+        {% for remedy in topic.remedies %}
+        <li class="mb-2">{{ remedy }}</li>
+        {% endfor %}
+      </ol>
+    </div>
+  </section>
+</article>
+<div class="d-flex gap-2">
+  <a class="btn btn-outline-success" href="{{ url_for('home') }}">Quay lại trang chủ</a>
+  <a class="btn btn-success" href="{{ url_for('news_list') }}">Xem thêm tin tức liên quan</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add environment-driven configuration for secrets, database URI, and domain values in the Flask app
- provide a deploy.sh helper plus README guidance to upload and run the site on hocai.site via Gunicorn and reverse proxy
- include gunicorn in dependencies for production deployment

## Testing
- python -m compileall app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69393b34be988327a667e2e45a9623d8)