### PR TITLE
Switch project database to MySQL; add deployment configs and pyproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
 # hocai
-học ai chơi sàn binane
+
+Nâng cấp thuocgiatruyen.org để chạy trên Python 3.12 và Django 5.x, sẵn sàng cho triển khai hiện đại.
+
+## Yêu cầu môi trường
+
+- Python >= 3.12
+- MySQL 8.x (khuyến nghị)
+
+## Cài đặt nhanh
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Cấu hình MySQL cho Django
+
+Ví dụ cấu hình trong `settings.py`:
+
+```python
+import os
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": os.getenv("MYSQL_DATABASE", "thuocgiatruyen"),
+        "USER": os.getenv("MYSQL_USER", "root"),
+        "PASSWORD": os.getenv("MYSQL_PASSWORD", ""),
+        "HOST": os.getenv("MYSQL_HOST", "127.0.0.1"),
+        "PORT": os.getenv("MYSQL_PORT", "3306"),
+        "OPTIONS": {
+            "charset": "utf8mb4",
+            "use_unicode": True,
+            "init_command": "SET sql_mode='STRICT_TRANS_TABLES'",
+        },
+        "CONN_MAX_AGE": 60,
+    }
+}
+```
+
+## Chạy song song dữ liệu trong 03 ngày
+
+Script `scripts/parallel_data_migration.py` hiện được thiết kế cho PostgreSQL. Nếu chuyển sang
+MySQL, nên triển khai song song dữ liệu bằng migration trong Django hoặc job ETL chuyên biệt.
+
+## Cấu hình hiệu năng đề xuất
+
+Các tệp cấu hình mẫu dưới đây giúp tối ưu tốc độ phản hồi cho môi trường production:
+
+- `deploy/gunicorn.conf.py`: cấu hình worker/threads, preload, giới hạn request.
+- `deploy/nginx.conf`: bật gzip, cache static/media, tối ưu proxy.
+
+### Gunicorn
+
+```bash
+gunicorn -c deploy/gunicorn.conf.py your_project.wsgi:application
+```
+
+### Nginx
+
+Sao chép nội dung `deploy/nginx.conf` vào cấu hình máy chủ và điều chỉnh đường dẫn
+`/var/www/thuocgiatruyen` cho phù hợp.

--- a/deploy/gunicorn.conf.py
+++ b/deploy/gunicorn.conf.py
@@ -1,0 +1,13 @@
+import multiprocessing
+
+workers = multiprocessing.cpu_count() * 2 + 1
+threads = 4
+worker_class = "gthread"
+keepalive = 5
+timeout = 30
+preload_app = True
+max_requests = 1000
+max_requests_jitter = 100
+accesslog = "-"
+errorlog = "-"
+loglevel = "info"

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,33 @@
+server {
+    listen 80;
+    server_name thuocgiatruyen.org www.thuocgiatruyen.org;
+
+    client_max_body_size 10m;
+
+    gzip on;
+    gzip_comp_level 5;
+    gzip_min_length 256;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
+
+    location /static/ {
+        alias /var/www/thuocgiatruyen/static/;
+        expires 30d;
+        add_header Cache-Control "public, max-age=2592000";
+    }
+
+    location /media/ {
+        alias /var/www/thuocgiatruyen/media/;
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800";
+    }
+
+    location / {
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+        proxy_read_timeout 60s;
+        proxy_connect_timeout 5s;
+        proxy_pass http://127.0.0.1:8000;
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "hocai"
+version = "0.1.0"
+description = "Nâng cấp nền tảng thuocgiatruyen.org lên Python mới nhất."
+requires-python = ">=3.12"
+
+[tool.black]
+line-length = 88
+
+target-version = ["py312"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django>=4.2,<5.0
-psycopg2-binary>=2.9
-gunicorn>=21.2
+Django>=5.1,<6.0
+mysqlclient>=2.2
+gunicorn>=22.0


### PR DESCRIPTION
### Motivation
- Move the project from a PostgreSQL-focused stack to MySQL to match deployment needs and environment constraints. 
- Remove a PostgreSQL-specific parallel-migration workflow that no longer applies when using MySQL. 
- Provide basic production deployment templates and modern Python metadata to prepare for Python 3.12 and Django 5.x.

### Description
- Update `requirements.txt` to use `mysqlclient>=2.2`, `Django>=5.1,<6.0`, and `gunicorn>=22.0` in place of the PostgreSQL driver. 
- Replace README guidance with MySQL-focused environment requirements and an example `DATABASES` configuration using `django.db.backends.mysql`. 
- Delete the PostgreSQL-only `scripts/parallel_data_migration.py` and add a note recommending Django migrations or ETL jobs for MySQL-based parallel migration. 
- Add deployment templates `deploy/gunicorn.conf.py` and `deploy/nginx.conf`, and add `pyproject.toml` with `requires-python = ">=3.12"` and basic `black` settings.

### Testing
- Ran `python -m compileall .` and the project files compiled successfully without errors. 
- No unit test suite or CI jobs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69703509a4608327ac6a4713ff6d1a0b)